### PR TITLE
Fix multiline Arithmetic precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ multiplication: primary ( ( "/" | "*" ) primary )*
 primary: number 
         ;
 
-number:  INTLITERAL
+number:  intliteral
+        ;
+
+intliteral: [0-9]*
         ;
 ```

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ multiplication: primary ( ( "/" | "*" ) primary )*
 primary: number 
         ;
 
-number:  intliteral
-        ;
-
-intliteral: [0-9]*
+number:  [0-9]*
         ;
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ mod tests {
         )
     }
 
-    #[ignore = "known broken but actively fixing"]
     #[test]
     fn should_interpret_arithmetic_input_with_arbitrary_whitespace() {
         let input: Vec<char> = "13 -6+  4*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,19 @@ mod tests {
             crate::parser::parse(&input).map(crate::ast::interpret::interpret)
         )
     }
+
+    #[ignore = "known broken but actively fixing"]
+    #[test]
+    fn should_interpret_arithmetic_input_with_arbitrary_whitespace() {
+        let input: Vec<char> = "13 -6+  4*
+        5
+               +
+        08 / 3"
+            .chars()
+            .collect();
+        assert_eq!(
+            Ok(crate::ast::IntegerConstant(29)),
+            crate::parser::parse(&input).map(crate::ast::interpret::interpret)
+        )
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -47,14 +47,11 @@ fn addition<'a>() -> impl parcel::Parser<'a, &'a [char], ExprNode> {
         ))
         .map(unzip),
     )
-    .map(|(lhe, (operators, operands))| {
-        let operands_iter = operands.into_iter();
-        let first: ExprNode = lhe;
-        let operators_iter = operators.into_iter();
-
-        operators_iter
-            .zip(operands_iter)
-            .fold(first, |lhs, (operator, rhs)| match operator {
+    .map(|(first_expr, (operators, operands))| {
+        operators
+            .into_iter()
+            .zip(operands.into_iter())
+            .fold(first_expr, |lhs, (operator, rhs)| match operator {
                 AdditionExprOp::Plus => ExprNode::Addition(Box::new(lhs), Box::new(rhs)),
                 AdditionExprOp::Minus => ExprNode::Subtraction(Box::new(lhs), Box::new(rhs)),
             })
@@ -82,14 +79,11 @@ fn multiplication<'a>() -> impl parcel::Parser<'a, &'a [char], ExprNode> {
         ))
         .map(unzip),
     )
-    .map(|(lhe, (operators, operands))| {
-        let operands_iter = operands.into_iter();
-        let first: ExprNode = lhe;
-        let operators_iter = operators.into_iter();
-
-        operators_iter
-            .zip(operands_iter)
-            .fold(first, |lhs, (operator, rhs)| match operator {
+    .map(|(first_expr, (operators, operands))| {
+        operators
+            .into_iter()
+            .zip(operands.into_iter())
+            .fold(first_expr, |lhs, (operator, rhs)| match operator {
                 MultiplicationExprOp::Star => {
                     ExprNode::Multiplication(Box::new(lhs), Box::new(rhs))
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -47,13 +47,9 @@ fn addition<'a>() -> impl parcel::Parser<'a, &'a [char], ExprNode> {
         ))
         .map(unzip),
     )
-    .map(|(lhe, (operators, mut operands))| {
-        operands.insert(0, lhe);
-        (operands, operators)
-    })
-    .map(|(operands, operators)| {
-        let mut operands_iter = operands.into_iter();
-        let first: ExprNode = operands_iter.next().unwrap();
+    .map(|(lhe, (operators, operands))| {
+        let operands_iter = operands.into_iter();
+        let first: ExprNode = lhe;
         let operators_iter = operators.into_iter();
 
         operators_iter
@@ -86,13 +82,9 @@ fn multiplication<'a>() -> impl parcel::Parser<'a, &'a [char], ExprNode> {
         ))
         .map(unzip),
     )
-    .map(|(lhe, (operators, mut operands))| {
-        operands.insert(0, lhe);
-        (operands, operators)
-    })
-    .map(|(operands, operators)| {
-        let mut operands_iter = operands.into_iter();
-        let first: ExprNode = operands_iter.next().unwrap();
+    .map(|(lhe, (operators, operands))| {
+        let operands_iter = operands.into_iter();
+        let first: ExprNode = lhe;
         let operators_iter = operators.into_iter();
 
         operators_iter


### PR DESCRIPTION
# Introduction
This PR addresses an issue where arithmetic operations were right associated instead of left associated this would cause expressions such as `13 - 6 + 4 * 5 + 8 / 3` which should yield `29` was instead causing underflow errors.

# Linked Issues
resolves #13 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
