### PR TITLE
Add register size constraints

### DIFF
--- a/src/codegen/allocator.rs
+++ b/src/codegen/allocator.rs
@@ -2,7 +2,7 @@
 pub type AllocatorEntityId = usize;
 
 /// Allocator represents any allocator that can allocate
-pub trait Allocator<T>
+pub trait Allocator
 where
     Self: Sized,
 {

--- a/src/codegen/machine/arch/x86_64.rs
+++ b/src/codegen/machine/arch/x86_64.rs
@@ -1,6 +1,6 @@
 use crate::codegen::allocator::Allocator;
 use crate::codegen::machine::arch::TargetArchitecture;
-use crate::codegen::register::Register;
+use crate::codegen::register::GeneralPurpose;
 
 /// X86_64 represents the x86_64 bit machine target.
 pub struct X86_64;
@@ -8,42 +8,46 @@ pub struct X86_64;
 impl TargetArchitecture for X86_64 {}
 
 #[derive(Debug, Clone)]
-pub struct RegisterAllocator {
-    registers: Vec<Register>,
-    allocated: Vec<bool>,
+pub struct GPRegisterAllocator {
+    general_purpose: [GeneralPurpose<u64>; 8],
+    general_purpose_allocated: [bool; 8],
 }
 
-impl Default for RegisterAllocator {
+impl Default for GPRegisterAllocator {
     fn default() -> Self {
         Self {
-            registers: vec![
-                Register::from("%r8"),
-                Register::from("%r9"),
-                Register::from("%r10"),
-                Register::from("%rx11"),
+            general_purpose: [
+                GeneralPurpose::new("%r8"),
+                GeneralPurpose::new("%r9"),
+                GeneralPurpose::new("%r10"),
+                GeneralPurpose::new("%r11"),
+                GeneralPurpose::new("%r12"),
+                GeneralPurpose::new("%r13"),
+                GeneralPurpose::new("%r14"),
+                GeneralPurpose::new("%r15"),
             ],
-            allocated: [false].iter().cycle().take(4).copied().collect(),
+            general_purpose_allocated: [false, false, false, false, false, false, false, false],
         }
     }
 }
 
-impl RegisterAllocator {
+impl GPRegisterAllocator {
     /// Optionally returns a register, by Id, if it exists.
-    pub fn register(&self, idx: usize) -> Option<Register> {
-        self.registers.get(idx).copied()
+    pub fn register(&self, idx: usize) -> Option<GeneralPurpose<u64>> {
+        self.general_purpose.get(idx).copied()
     }
 
-    pub fn register_ids() -> Vec<&'static str> {
-        vec!["%r8", "%r9", "%r10", "%r11"]
+    pub fn register_ids(&self) -> Vec<&'static str> {
+        self.general_purpose.iter().map(|reg| reg.id()).collect()
     }
 }
 
-impl Allocator<Register> for RegisterAllocator {
+impl Allocator<GeneralPurpose<u64>> for GPRegisterAllocator {
     /// Finds the first unallocated register, if one is found it is returned
     /// as an option.
     fn allocate_mut(&mut self) -> Option<usize> {
         if let Some(idx) = get_unallocated_register(self) {
-            self.allocated[idx] = true;
+            self.general_purpose_allocated[idx] = true;
             Some(idx)
         } else {
             None
@@ -58,7 +62,7 @@ impl Allocator<Register> for RegisterAllocator {
     }
 
     fn free_mut(&mut self, idx: usize) -> Option<usize> {
-        if let Some(alloc) = self.allocated.get_mut(idx) {
+        if let Some(alloc) = self.general_purpose_allocated.get_mut(idx) {
             *alloc = false;
             Some(idx)
         } else {
@@ -72,7 +76,7 @@ impl Allocator<Register> for RegisterAllocator {
     }
 
     fn free_all_mut(&mut self) {
-        self.allocated = [false].iter().cycle().copied().take(4).collect();
+        self.general_purpose_allocated = [false, false, false, false, false, false, false, false]
     }
 
     fn free_all(mut self) -> Self {
@@ -82,8 +86,8 @@ impl Allocator<Register> for RegisterAllocator {
 }
 
 /// Finds the first unallocated register, if any, If any are available the offset is returned.
-fn get_unallocated_register(ra: &RegisterAllocator) -> Option<usize> {
-    ra.allocated
+fn get_unallocated_register(ra: &GPRegisterAllocator) -> Option<usize> {
+    ra.general_purpose_allocated
         .iter()
         .enumerate()
         .filter_map(|(idx, allocated)| if *allocated { None } else { Some(idx) })

--- a/src/codegen/machine/arch/x86_64.rs
+++ b/src/codegen/machine/arch/x86_64.rs
@@ -93,3 +93,30 @@ fn get_unallocated_register(ra: &GPRegisterAllocator) -> Option<usize> {
         .filter_map(|(idx, allocated)| if *allocated { None } else { Some(idx) })
         .next()
 }
+
+pub const CG_PREAMBLE: &str = "\t.text
+.LC0:
+    .string \"%d\\n\"
+printint:
+    pushq   %rbp
+    movq    %rsp, %rbp
+    subq    $16, %rsp
+    movl    %edi, -4(%rbp)
+    movl    -4(%rbp), %eax
+    movl    %eax, %esi
+    leaq	.LC0(%rip), %rdi
+    movl	$0, %eax
+    call	printf@PLT
+    nop
+    leave
+    ret
+	
+    .globl  main
+    .type   main, @function
+main:
+    pushq   %rbp
+    movq	%rsp, %rbp\n";
+
+pub const CG_POSTAMBLE: &str = "\tmovl	$0, %eax
+    popq	%rbp
+    ret\n";

--- a/src/codegen/machine/arch/x86_64.rs
+++ b/src/codegen/machine/arch/x86_64.rs
@@ -42,7 +42,7 @@ impl GPRegisterAllocator {
     }
 }
 
-impl Allocator<GeneralPurpose<u64>> for GPRegisterAllocator {
+impl Allocator for GPRegisterAllocator {
     /// Finds the first unallocated register, if one is found it is returned
     /// as an option.
     fn allocate_mut(&mut self) -> Option<usize> {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -88,42 +88,17 @@ impl CodeGenerator
 
 type RegisterId = usize;
 
-const X86_64_PREAMBLE: &str = "\t.text
-.LC0:
-    .string\t\"%d\\n\"
-printint:
-    pushq\t%rbp
-    movq\t%rsp, %rbp
-    subq\t$16, %rsp
-    movl\t%edi, -4(%rbp)
-    movl\t-4(%rbp), %eax
-    movl\t%eax, %esi
-    leaq	.LC0(%rip), %rdi
-    movl	$0, %eax
-    call	printf@PLT
-    nop
-    leave
-    ret
-	
-    .globl\tmain
-    .type\tmain, @function
-main:
-    pushq\t%rbp
-    movq	%rsp, %rbp\n";
-
-const X86_64_POSTAMBLE: &str = "\tmovl	$0, %eax
-    popq	%rbp
-    ret\n";
-
 impl
     TargetCodeGenerator<machine::arch::x86_64::X86_64, machine::arch::x86_64::GPRegisterAllocator>
 {
     fn codegen_preamble(&mut self) {
-        self.context.push(String::from(X86_64_PREAMBLE));
+        self.context
+            .push(String::from(machine::arch::x86_64::CG_PREAMBLE));
     }
 
     fn codegen_postamble(&mut self) {
-        self.context.push(String::from(X86_64_POSTAMBLE));
+        self.context
+            .push(String::from(machine::arch::x86_64::CG_POSTAMBLE));
     }
 
     fn codegen_printint(&mut self, reg_id: RegisterId) {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -35,7 +35,7 @@ pub trait CodeGenerator {
 pub struct TargetCodeGenerator<T, A>
 where
     T: machine::arch::TargetArchitecture,
-    A: allocator::Allocator<register::GeneralPurpose<u64>>,
+    A: allocator::Allocator,
 {
     target_architecture: std::marker::PhantomData<T>,
     allocator: A,
@@ -45,7 +45,7 @@ where
 impl<T, R> TargetCodeGenerator<T, R>
 where
     T: machine::arch::TargetArchitecture,
-    R: allocator::Allocator<register::GeneralPurpose<u64>> + Default,
+    R: allocator::Allocator + Default,
 {
     pub fn new() -> Self {
         Self::default()
@@ -55,7 +55,7 @@ where
 impl<T, R> Default for TargetCodeGenerator<T, R>
 where
     T: machine::arch::TargetArchitecture,
-    R: allocator::Allocator<register::GeneralPurpose<u64>> + Default,
+    R: allocator::Allocator + Default,
 {
     fn default() -> Self {
         Self {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -35,7 +35,7 @@ pub trait CodeGenerator {
 pub struct TargetCodeGenerator<T, A>
 where
     T: machine::arch::TargetArchitecture,
-    A: allocator::Allocator<register::Register>,
+    A: allocator::Allocator<register::GeneralPurpose<u64>>,
 {
     target_architecture: std::marker::PhantomData<T>,
     allocator: A,
@@ -45,7 +45,7 @@ where
 impl<T, R> TargetCodeGenerator<T, R>
 where
     T: machine::arch::TargetArchitecture,
-    R: allocator::Allocator<register::Register> + Default,
+    R: allocator::Allocator<register::GeneralPurpose<u64>> + Default,
 {
     pub fn new() -> Self {
         Self::default()
@@ -55,7 +55,7 @@ where
 impl<T, R> Default for TargetCodeGenerator<T, R>
 where
     T: machine::arch::TargetArchitecture,
-    R: allocator::Allocator<register::Register> + Default,
+    R: allocator::Allocator<register::GeneralPurpose<u64>> + Default,
 {
     fn default() -> Self {
         Self {
@@ -67,7 +67,10 @@ where
 }
 
 impl CodeGenerator
-    for TargetCodeGenerator<machine::arch::x86_64::X86_64, machine::arch::x86_64::RegisterAllocator>
+    for TargetCodeGenerator<
+        machine::arch::x86_64::X86_64,
+        machine::arch::x86_64::GPRegisterAllocator,
+    >
 {
     fn generate(mut self, input: ast::StmtNode) -> Result<Vec<String>, CodeGenerationErr> {
         self.codegen_preamble();
@@ -112,7 +115,9 @@ const X86_64_POSTAMBLE: &str = "\tmovl	$0, %eax
     popq	%rbp
     ret\n";
 
-impl TargetCodeGenerator<machine::arch::x86_64::X86_64, machine::arch::x86_64::RegisterAllocator> {
+impl
+    TargetCodeGenerator<machine::arch::x86_64::X86_64, machine::arch::x86_64::GPRegisterAllocator>
+{
     fn codegen_preamble(&mut self) {
         self.context.push(String::from(X86_64_PREAMBLE));
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4,8 +4,6 @@ pub mod allocator;
 pub mod machine;
 mod register;
 
-use allocator::Allocator;
-
 /// CodeGenerationErr represents an error stemming from the CodeGenerator's
 /// `generate` method, capturing any potential point of breakdown withing the
 /// code generation process.
@@ -62,110 +60,6 @@ where
             target_architecture: std::marker::PhantomData,
             allocator: <R>::default(),
             context: Vec::new(),
-        }
-    }
-}
-
-impl CodeGenerator
-    for TargetCodeGenerator<
-        machine::arch::x86_64::X86_64,
-        machine::arch::x86_64::GPRegisterAllocator,
-    >
-{
-    fn generate(mut self, input: ast::StmtNode) -> Result<Vec<String>, CodeGenerationErr> {
-        self.codegen_preamble();
-        match input {
-            ast::StmtNode::Expression(expr) => {
-                let reg_id = self.codegen_expr(expr);
-                self.codegen_printint(reg_id);
-            }
-        };
-
-        self.codegen_postamble();
-        Ok(self.context)
-    }
-}
-
-type RegisterId = usize;
-
-impl
-    TargetCodeGenerator<machine::arch::x86_64::X86_64, machine::arch::x86_64::GPRegisterAllocator>
-{
-    fn codegen_preamble(&mut self) {
-        self.context
-            .push(String::from(machine::arch::x86_64::CG_PREAMBLE));
-    }
-
-    fn codegen_postamble(&mut self) {
-        self.context
-            .push(String::from(machine::arch::x86_64::CG_POSTAMBLE));
-    }
-
-    fn codegen_printint(&mut self, reg_id: RegisterId) {
-        let reg = self.allocator.register(reg_id).unwrap();
-
-        self.context
-            .push(format!("\tmovq\t{}, %rdi\n\tcall\tprintint\n", reg));
-        self.allocator.free_mut(reg_id);
-    }
-
-    fn codegen_expr(&mut self, expr: ast::ExprNode) -> RegisterId {
-        use ast::{ExprNode, Primary};
-
-        match expr {
-            ExprNode::Primary(Primary::Uint8(ast::Uint8(ic))) => {
-                let reg_id = self.allocator.allocate_mut().unwrap();
-                let reg = self.allocator.register(reg_id).unwrap();
-                self.context.push(format!("\tmovq\t${}, {}\n", ic, reg));
-                reg_id
-            }
-
-            ExprNode::Addition(lhs, rhs) => {
-                let r1_id = self.codegen_expr(*lhs);
-                let r2_id = self.codegen_expr(*rhs);
-                let r1 = self.allocator.register(r1_id).unwrap();
-                let r2 = self.allocator.register(r2_id).unwrap();
-
-                self.context.push(format!("\taddq\t{}, {}\n", r1, r2));
-                self.allocator.free_mut(r1_id);
-                r2_id
-            }
-
-            ExprNode::Subtraction(lhs, rhs) => {
-                let r1_id = self.codegen_expr(*lhs);
-                let r2_id = self.codegen_expr(*rhs);
-                let r1 = self.allocator.register(r1_id).unwrap();
-                let r2 = self.allocator.register(r2_id).unwrap();
-
-                self.context.push(format!("\tsubq\t{}, {}\n", r2, r1));
-                self.allocator.free_mut(r2_id);
-                r1_id
-            }
-
-            ExprNode::Multiplication(lhs, rhs) => {
-                let r1_id = self.codegen_expr(*lhs);
-                let r2_id = self.codegen_expr(*rhs);
-                let r1 = self.allocator.register(r1_id).unwrap();
-                let r2 = self.allocator.register(r2_id).unwrap();
-
-                self.context.push(format!("\timulq\t{}, {}\n", r1, r2));
-                self.allocator.free_mut(r1_id);
-                r2_id
-            }
-
-            ExprNode::Division(lhs, rhs) => {
-                let r1_id = self.codegen_expr(*lhs);
-                let r2_id = self.codegen_expr(*rhs);
-                let r1 = self.allocator.register(r1_id).unwrap();
-                let r2 = self.allocator.register(r2_id).unwrap();
-
-                self.context.push(format!("\tmovq\t{},%%rax\n", r1));
-                self.context.push(String::from("\tcqo\n"));
-                self.context.push(format!("\tidivq\t{}\n", r2));
-                self.context.push(format!("\tmovq\t%%rax,{}\n", r1));
-                self.allocator.free_mut(r2_id);
-                r1_id
-            }
         }
     }
 }

--- a/src/codegen/register.rs
+++ b/src/codegen/register.rs
@@ -1,29 +1,67 @@
-/// Register represents a string representable register that can be used both by
-/// allocators and by code generation.
-#[derive(Debug, Clone, Copy)]
-pub struct Register {
-    repr: &'static str,
+/// Register implements the methods for register to store a value of a given size.
+pub trait Register<R, W> {
+    fn read(&self) -> R;
+    fn write(self, value: W) -> Self;
+    fn with_value(self, value: W) -> Self;
 }
 
-impl Register {
+/// GeneralPurpose register represents a string representable register that can
+/// be used both by allocators and by code generation.
+#[derive(Debug, Clone, Copy)]
+pub struct GeneralPurpose<V> {
+    repr: &'static str,
+    inner: V,
+}
+
+impl<V> GeneralPurpose<V>
+where
+    V: Default,
+{
     /// instantiates a register with the str representation passed as `repr`.
     pub fn new(repr: &'static str) -> Self {
-        Self { repr }
+        Self {
+            repr,
+            inner: <V>::default(),
+        }
     }
+}
 
+impl<V> GeneralPurpose<V> {
     /// returns the string representation of the register.
     pub fn id(&self) -> &'static str {
         self.repr
     }
 }
 
-impl From<&'static str> for Register {
+impl<V> Register<V, V> for GeneralPurpose<V>
+where
+    V: Copy,
+{
+    fn read(&self) -> V {
+        self.inner
+    }
+
+    fn write(mut self, value: V) -> Self {
+        self.inner = value;
+        self
+    }
+
+    fn with_value(mut self, value: V) -> Self {
+        self.inner = value;
+        self
+    }
+}
+
+impl<V> From<&'static str> for GeneralPurpose<V>
+where
+    V: Default,
+{
     fn from(repr: &'static str) -> Self {
         Self::new(repr)
     }
 }
 
-impl std::fmt::Display for Register {
+impl<V> std::fmt::Display for GeneralPurpose<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.repr)
     }

--- a/src/codegen/register.rs
+++ b/src/codegen/register.rs
@@ -1,5 +1,8 @@
 /// Register implements the methods for register to store a value of a given size.
-pub trait Register<R, W> {
+pub trait Register<R, W>
+where
+    Self: Copy,
+{
     fn read(&self) -> R;
     fn write(self, value: W) -> Self;
     fn with_value(self, value: W) -> Self;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn compile(source: String) -> RuntimeResult<()> {
             use mossy::codegen::machine::arch::x86_64;
             use mossy::codegen::{CodeGenerator, TargetCodeGenerator};
 
-            TargetCodeGenerator::<x86_64::X86_64, x86_64::RegisterAllocator>::new()
+            TargetCodeGenerator::<x86_64::X86_64, x86_64::GPRegisterAllocator>::new()
                 .generate(ast_node[0].to_owned())
         })
         .unwrap()


### PR DESCRIPTION
# Introduction
This PR includes some refactors that:
- Constrain registers by size
- Move architecture specific implementations to a corresponding directory
- Extend the behavior of registers

# Linked Issues
resolves #27

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
