### PR TITLE
Break out the allocator and code generation

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -27,39 +27,3 @@ impl std::fmt::Debug for CodeGenerationErr {
 pub trait CodeGenerator {
     fn generate(self, input: ast::StmtNode) -> Result<Vec<String>, CodeGenerationErr>;
 }
-
-/// TargetCodeGenerator implmements CodeGenerator, storing code context,
-/// register allocator and other metadata for a specific architecture.
-pub struct TargetCodeGenerator<T, A>
-where
-    T: machine::arch::TargetArchitecture,
-    A: allocator::Allocator,
-{
-    target_architecture: std::marker::PhantomData<T>,
-    allocator: A,
-    context: Vec<String>,
-}
-
-impl<T, R> TargetCodeGenerator<T, R>
-where
-    T: machine::arch::TargetArchitecture,
-    R: allocator::Allocator + Default,
-{
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl<T, R> Default for TargetCodeGenerator<T, R>
-where
-    T: machine::arch::TargetArchitecture,
-    R: allocator::Allocator + Default,
-{
-    fn default() -> Self {
-        Self {
-            target_architecture: std::marker::PhantomData,
-            allocator: <R>::default(),
-            context: Vec::new(),
-        }
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,10 +49,9 @@ fn compile(source: String) -> RuntimeResult<()> {
         .map_err(|e| format!("{:?}", e))
         .map(|ast_node| {
             use mossy::codegen::machine::arch::x86_64;
-            use mossy::codegen::{CodeGenerator, TargetCodeGenerator};
+            use mossy::codegen::CodeGenerator;
 
-            TargetCodeGenerator::<x86_64::X86_64, x86_64::GPRegisterAllocator>::new()
-                .generate(ast_node[0].to_owned())
+            x86_64::X86_64.generate(ast_node[0].to_owned())
         })
         .unwrap()
         .map(|insts| {


### PR DESCRIPTION
# Introduction
This is a small PR to breakout the Allocator and the Code Generator traits in preparation for further cleanup. This moves away from using TargetCodeGenerator in favor of association these with a corresponding architecture trait.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
