### PR TITLE
Switch mossy to use scrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ lto = true
 
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.0" }
+scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.2" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,113 @@
 use mossy::{codegen::CodeGenerationErr, parser};
+use scrap::prelude::v1::*;
 use std::env;
+use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
-use std::process;
 
-type RuntimeResult<T> = Result<T, String>;
+const EXIT_SUCCESS: i32 = 0;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    let args_len = args.len();
+const ROOT_HELP_STRING: &str = "Usage: mossy [OPTIONS]
+An (irresponsibly) experimental C compiler.
 
-    match args_len {
-        2 => run_file(&args[1]).expect("Unable to open file"),
-        _ => {
-            println!("Usage: mossy [script]");
-            process::exit(64);
+Flags:
+    --help, -h          print help string
+    --version, -v       
+    --in-file, -i       an input source file.
+    --out-file, -o      an output path assembly
+
+Subcommands:   
+";
+
+type RuntimeResult<T> = Result<T, RuntimeError>;
+
+enum RuntimeError {
+    InvalidArguments(String),
+    FileUnreadable,
+    Undefined(String),
+}
+
+impl fmt::Debug for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidArguments(hs) => write!(f, "{}", hs),
+            Self::FileUnreadable => write!(f, "source file unreadable"),
+            Self::Undefined(s) => write!(f, "{}", s),
         }
     }
 }
 
-fn run_file(filename: &str) -> Result<(), String> {
-    let mut f = File::open(filename).expect("file not found");
+impl fmt::Display for RuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", &self)
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let res = Cmd::new()
+        .name("mossy")
+        .description("An (irresponsibly) experimental C compiler.")
+        .author("Nate Catelli <ncatelli@packetfire.org>")
+        .version("0.1.0")
+        .flag(
+            Flag::new()
+                .name("version")
+                .short_code("v")
+                .action(Action::StoreTrue)
+                .value_type(ValueType::Bool),
+        )
+        .flag(
+            Flag::new()
+                .name("in-file")
+                .short_code("i")
+                .help_string("an input source file.")
+                .value_type(ValueType::Str),
+        )
+        .flag(
+            Flag::new()
+                .name("out-file")
+                .short_code("o")
+                .help_string("an output path assembly")
+                .value_type(ValueType::Str)
+                .default_value(Value::Str("a.s".to_string())),
+        )
+        .handler(Box::new(|c| {
+            let inf = c.get("in-file");
+            let ouf = c.get("out-file");
+            match (inf, ouf) {
+                (Some(Value::Str(in_f)), Some(Value::Str(out_f))) => Ok((in_f, out_f)),
+                _ => Err(RuntimeError::InvalidArguments(ROOT_HELP_STRING.to_string())),
+            }
+            .map(|(in_f, out_f)| {
+                read_src_file(&in_f)
+                    .map(|input| compile(&input))?
+                    .map(|asm| write_dest_file(&out_f, &asm.as_bytes()).map(|_| EXIT_SUCCESS))?
+            })
+            .and_then(std::convert::identity)
+            .map_err(|e| format!("{}", e))
+        }))
+        .run(args)
+        .unwrap()
+        .dispatch();
+
+    match res {
+        Ok(_) => (),
+        Err(e) => {
+            println!("{}", e);
+            std::process::exit(1)
+        }
+    }
+}
+
+fn read_src_file(filename: &str) -> RuntimeResult<String> {
+    let mut f = File::open(filename).map_err(|_| RuntimeError::FileUnreadable)?;
 
     let mut contents = String::new();
     match f.read_to_string(&mut contents) {
-        Ok(_) => compile(contents),
-        Err(error) => Err(format!("error: {}", error)),
+        Ok(_) => Ok(contents),
+        Err(e) => Err(RuntimeError::Undefined(e.to_string())),
     }
 }
 
@@ -35,22 +117,22 @@ fn write_dest_file(filename: &str, data: &[u8]) -> RuntimeResult<()> {
         .create(true)
         .write(true)
         .open(filename)
-        .map_err(|e| e.to_string())?;
+        .map_err(|_| RuntimeError::FileUnreadable)?;
 
     match f.write_all(data) {
         Ok(_) => Ok(()),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(RuntimeError::Undefined(e.to_string())),
     }
 }
 
-fn compile(source: String) -> RuntimeResult<()> {
+fn compile(source: &str) -> RuntimeResult<String> {
     use mossy::codegen::machine::arch::x86_64;
     use mossy::codegen::CodeGenerator;
     let input: Vec<(usize, char)> = source.chars().enumerate().collect();
     let mut symbol_table = x86_64::SymbolTable::default();
 
     parser::parse(&input)
-        .map_err(|e| format!("{:?}", e))?
+        .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))?
         .into_iter()
         .map(|ast_node| x86_64::X86_64.generate(&mut symbol_table, ast_node.to_owned()))
         .collect::<Result<Vec<Vec<String>>, CodeGenerationErr>>()
@@ -67,9 +149,7 @@ fn compile(source: String) -> RuntimeResult<()> {
         })
         .map(|insts: Vec<String>| {
             let contents = insts.into_iter().collect::<String>();
-            write_dest_file("a.s", contents.as_bytes()).unwrap();
+            contents
         })
-        .map_err(|e| format!("{:?}", e))?;
-
-    Ok(())
+        .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ fn compile(source: &str) -> RuntimeResult<String> {
     parser::parse(&input)
         .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))?
         .into_iter()
-        .map(|ast_node| x86_64::X86_64.generate(&mut symbol_table, ast_node.to_owned()))
+        .map(|ast_node| x86_64::X86_64.generate(&mut symbol_table, ast_node))
         .collect::<Result<Vec<Vec<String>>, CodeGenerationErr>>()
         .map(|insts| {
             vec![
@@ -147,9 +147,6 @@ fn compile(source: &str) -> RuntimeResult<String> {
             .flatten()
             .collect()
         })
-        .map(|insts: Vec<String>| {
-            let contents = insts.into_iter().collect::<String>();
-            contents
-        })
+        .map(|insts: Vec<String>| insts.into_iter().collect::<String>())
         .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))
 }


### PR DESCRIPTION
# Introduction
This PR makes the swap from a hand rolled cli, to using `scrap`.

# Linked Issues
resolves #39 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
