### PR TITLE
Update mossy to use scrap pre-release for `1.0.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ lto = true
 
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.0" }
-scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.2" }
+scrap = { git = "https://github.com/ncatelli/scrap", branch = "main" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,7 @@ fn main() {
                 .map(|input| compile(&input))
                 .unwrap()
                 .map(|asm| write_dest_file(&ouf, &asm.as_bytes()).map(|_| EXIT_SUCCESS))
-                .map_err(|e| format!("{}", e))
-                .unwrap()
+                .and_then(std::convert::identity)
                 .unwrap();
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,22 +7,9 @@ use std::io::prelude::*;
 
 const EXIT_SUCCESS: i32 = 0;
 
-const ROOT_HELP_STRING: &str = "Usage: mossy [OPTIONS]
-An (irresponsibly) experimental C compiler.
-
-Flags:
-    --help, -h          print help string
-    --version, -v       
-    --in-file, -i       an input source file.
-    --out-file, -o      an output path assembly
-
-Subcommands:   
-";
-
 type RuntimeResult<T> = Result<T, RuntimeError>;
 
 enum RuntimeError {
-    InvalidArguments(String),
     FileUnreadable,
     Undefined(String),
 }
@@ -30,7 +17,6 @@ enum RuntimeError {
 impl fmt::Debug for RuntimeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidArguments(hs) => write!(f, "{}", hs),
             Self::FileUnreadable => write!(f, "source file unreadable"),
             Self::Undefined(s) => write!(f, "{}", s),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,8 @@ fn main() {
         .with_handler(|(inf, ouf)| {
             read_src_file(&inf)
                 .map(|input| compile(&input))
-                .unwrap()
-                .map(|asm| write_dest_file(&ouf, &asm.as_bytes()).map(|_| EXIT_SUCCESS))
                 .and_then(std::convert::identity)
-                .unwrap();
+                .map(|asm| write_dest_file(&ouf, &asm.as_bytes()).map(|_| EXIT_SUCCESS))
         });
 
     let help_string = cmd.help();


### PR DESCRIPTION
# Introduction
This PR moves from scrap `v0.1.2` to the new pre-release target. This will eventually need to be moved to the official release once that is cut per #42.


# Linked Issues
resolves #41 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
