### PR TITLE
Simplify if statement to fall through on a true condition

### DIFF
--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -173,14 +173,16 @@ impl CodeGenerator<SymbolTable, ast::CompoundStmts> for X86_64 {
             .enumerate()
             .map(|(block_id, block)| (codegen_label(block_id), block))
             .map(|(label, block)| {
+                let block_id = block.id;
                 let inner = block.inner;
                 let (ec_true, ec_false) = (block.exit_cond_true, block.exit_cond_false);
                 let inner_and_exit: Vec<String> = match (ec_true, ec_false) {
+                    (Some(next), None) if next == block_id + 1 => inner,
                     (Some(next), None) => inner
                         .into_iter()
                         .chain(codegen_jump(next).into_iter())
                         .collect(),
-                    _ => inner.into_iter().collect(),
+                    _ => inner,
                 };
 
                 (label, inner_and_exit)

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -180,10 +180,7 @@ impl CodeGenerator<SymbolTable, ast::CompoundStmts> for X86_64 {
                         .into_iter()
                         .chain(codegen_jump(next).into_iter())
                         .collect(),
-                    _ => inner
-                        .into_iter()
-                        .chain(vec!["\tjmp\tpostamble\n".to_string()].into_iter())
-                        .collect(),
+                    _ => inner.into_iter().collect(),
                 };
 
                 (label, inner_and_exit)
@@ -271,8 +268,12 @@ fn codegen_if_statement(
     allocator.allocate_then(|allocator, ret_val| {
         let parent_block_id = ctx.active_block;
         let mut cond_ctx = codegen_expr(ctx, allocator, ret_val, cond);
+        let exit_block_id = if false_case.is_some() {
+            parent_block_id + 3
+        } else {
+            parent_block_id + 2
+        };
 
-        let exit_block_id = cond_ctx.derive_child_from_parent(parent_block_id);
         let true_case_block_id = cond_ctx.derive_child_from_parent(parent_block_id);
         cond_ctx
             .get_mut(parent_block_id)
@@ -295,16 +296,20 @@ fn codegen_if_statement(
             (tctx, exit_block_id)
         };
 
-        // reset to parent
+        // reset parent block for compare.
         block_ctx.active_block = parent_block_id;
-
-        Ok(codegen_compare_and_jump(
+        let mut compare_block = codegen_compare_and_jump(
             block_ctx,
             allocator,
             ret_val,
             true_case_block_id,
             else_block_id,
-        ))
+        );
+
+        // generate an exit block
+        compare_block.derive_child_from_parent(parent_block_id);
+
+        Ok(compare_block)
     })
 }
 
@@ -599,7 +604,7 @@ fn codegen_compare_and_jump(
     mut ctx: BuildContext<Vec<String>>,
     allocator: &mut GPRegisterAllocator,
     ret_val: &mut SizedGeneralPurpose,
-    cond_true_id: BlockId,
+    _cond_true_id: BlockId,
     cond_false_id: BlockId,
 ) -> BuildContext<Vec<String>> {
     allocator.allocate_then(|_, zero_val| {
@@ -616,10 +621,9 @@ fn codegen_compare_and_jump(
                         SizedGeneralPurpose::Byte(ret_val.id())
                     ),
                     format!("\tandq\t$255,{}\n", ret_val),
-                    format!("\t{}\tL{}\n", "je", cond_true_id),
+                    format!("\t{}\tL{}\n", "jne", cond_false_id),
                 ]
                 .into_iter()
-                .chain(codegen_jump(cond_false_id).into_iter())
                 .collect(),
             )
         });


### PR DESCRIPTION
# Introduction
This PR strips a few extra jmp instructions by lining up conditional instructions to fall through on passing test cases. This also makes a few additional changes to ensure jumps don't erroneously get added where fallthrough is sufficient.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
