### PR TITLE
Remove printint from expression nodes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,7 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.145.1/containers/rust/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust/.devcontainer/base.Dockerfile
 
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/rust
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust
 {
 	"name": "Rust",
 	"build": {
@@ -10,26 +10,32 @@
 		"--security-opt",
 		"seccomp=unconfined"
 	],
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"lldb.executable": "/usr/bin/lldb",
 		// VS Code don't watch files under ./target
 		"files.watcherExclude": {
 			"**/target/**": true
-		}
+		},
+		"rust-analyzer.checkOnSave.command": "clippy"
 	},
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"matklad.rust-analyzer",
-		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor",
-		"ms-vscode.cpptools"
+		"matklad.rust-analyzer",
+		"tamasfe.even-better-toml",
+		"serayuzgur.crates"
 	],
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
+
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -87,7 +87,7 @@ fn codegen_statements(
 
     stmts
         .into_iter()
-        .map(|stmt| codegen_statement(allocator, symboltable, stmt).map(|output| output.join("\n")))
+        .map(|stmt| codegen_statement(allocator, symboltable, stmt).map(|output| output.join("")))
         .collect::<Result<Vec<String>, _>>()
 }
 

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -97,12 +97,8 @@ fn codegen_statement(
     input: ast::StmtNode,
 ) -> Result<Vec<String>, codegen::CodeGenerationErr> {
     match input {
-        ast::StmtNode::Expression(expr) => allocator.allocate_then(|allocator, ret_val| {
-            Ok(vec![
-                codegen_expr(allocator, ret_val, expr),
-                codegen_printint(ret_val),
-            ])
-        }),
+        ast::StmtNode::Expression(expr) => allocator
+            .allocate_then(|allocator, ret_val| Ok(vec![codegen_expr(allocator, ret_val, expr)])),
         ast::StmtNode::Declaration(identifier) => {
             symboltable.declare_global(&identifier);
             Ok(vec![codegen_global_symbol(&identifier)])
@@ -443,6 +439,7 @@ fn codegen_compare_and_jmp(
     })
 }
 
+#[allow(dead_code)]
 fn codegen_printint(reg: &mut SizedGeneralPurpose) -> Vec<String> {
     vec![format!(
         "\tmov{}\t{}, %rdi\n\tcall\tprintint\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
         .with_handler(|(inf, ouf)| {
             read_src_file(&inf)
                 .and_then(|input| compile(&input))
-                .and_then(|asm| write_dest_file(&ouf, &asm.as_bytes()))
+                .and_then(|asm| write_dest_file(&ouf, asm.as_bytes()))
         });
 
     let help_string = cmd.help();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -35,14 +35,14 @@ fn compound_statements<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Com
             whitespace_wrapped(expect_character('}')),
         )),
     ))
-    .map(|stmts| CompoundStmts::new(stmts))
+    .map(CompoundStmts::new)
 }
 
 fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
     expression_statement()
-        .or(|| declaration_statement())
-        .or(|| assignment_statement())
-        .or(|| if_statement())
+        .or(declaration_statement)
+        .or(assignment_statement)
+        .or(if_statement)
 }
 
 fn declaration_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
@@ -77,9 +77,7 @@ fn if_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> 
             whitespace_wrapped(expect_str("else")).and_then(|_| compound_statements()),
         ),
     )
-    .map(|((cond, cond_true), cond_false)| {
-        StmtNode::If(cond, cond_true, cond_false.map(|stmts| stmts))
-    })
+    .map(|((cond, cond_true), cond_false)| StmtNode::If(cond, cond_true, cond_false))
 }
 
 fn if_head<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], (ExprNode, CompoundStmts)> {


### PR DESCRIPTION
# Introduction
This PR removes printint calls from the end of expressions. Additionally this includes clippy lint fixes and an update to the devcontainer.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
