### PR TITLE
Separate Integers out into width

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -143,15 +143,17 @@ pub enum Signed {
 }
 
 /// Represents valid integer bit widths.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub enum IntegerWidth {
     Eight,
+    ThirtyTwo,
 }
 
 impl ByteSized for IntegerWidth {
     fn size(&self) -> usize {
         match self {
             Self::Eight => 1,
+            Self::ThirtyTwo => 4,
         }
     }
 }
@@ -160,7 +162,6 @@ impl ByteSized for IntegerWidth {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
     Integer(Signed, IntegerWidth),
-    Char,
     Void,
     Func { return_type: Box<Type> },
 }
@@ -169,7 +170,6 @@ impl ByteSized for Type {
     fn size(&self) -> usize {
         match self {
             Self::Integer(_, iw) => iw.size(),
-            Self::Char => 1,
             Self::Void => 0,
             Self::Func { .. } => (usize::BITS / 8) as usize,
         }
@@ -180,11 +180,17 @@ impl ByteSized for Type {
 pub(crate) fn type_compatible(left: Type, right: Type, flow_left: bool) -> CompatibilityResult {
     match (left, right) {
         (lhs, rhs) if lhs == rhs => CompatibilityResult::Equivalent,
-        (Type::Integer(sign, width), Type::Char) => {
-            CompatibilityResult::WidenTo(Type::Integer(sign, width))
+        (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
+            if l_width != r_width && l_sign == r_sign =>
+        {
+            let widen_to_width = if l_width > r_width { l_width } else { r_width };
+            CompatibilityResult::WidenTo(Type::Integer(l_sign, widen_to_width))
         }
-        (Type::Char, Type::Integer(sign, width)) if !flow_left => {
-            CompatibilityResult::WidenTo(Type::Integer(sign, width))
+        (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
+            if l_width >= r_width && l_sign == r_sign && !flow_left =>
+        {
+            let widen_to_width = if l_width > r_width { l_width } else { r_width };
+            CompatibilityResult::WidenTo(Type::Integer(l_sign, widen_to_width))
         }
         _ => CompatibilityResult::Incompatible,
     }

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -314,6 +314,18 @@ fn codegen_expr(
             _,
             Primary::Integer {
                 sign: Signed::Unsigned,
+                width: IntegerWidth::ThirtyTwo,
+                value,
+            },
+        ) => {
+            let uc = core::convert::TryFrom::try_from(value)
+                .expect("value exceeds unsigned 32-bit integer");
+            codegen_constant_u32(ret_val, uc)
+        }
+        TypedExprNode::Primary(
+            _,
+            Primary::Integer {
+                sign: Signed::Unsigned,
                 width: IntegerWidth::Eight,
                 value,
             },
@@ -326,7 +338,7 @@ fn codegen_expr(
             _,
             Primary::Integer {
                 sign: Signed::Signed,
-                width: IntegerWidth::Eight,
+                width: _,
                 value: _,
             },
         ) => {
@@ -372,6 +384,15 @@ fn codegen_expr(
         }
         TypedExprNode::Division(_, lhs, rhs) => codegen_division(allocator, ret_val, lhs, rhs),
     }
+}
+
+fn codegen_constant_u32(ret_val: &mut SizedGeneralPurpose, constant: u32) -> Vec<String> {
+    vec![format!(
+        "\tmov{}\t${}, {}\n",
+        ret_val.operator_suffix(),
+        constant,
+        ret_val
+    )]
 }
 
 fn codegen_constant_u8(ret_val: &mut SizedGeneralPurpose, constant: u8) -> Vec<String> {

--- a/src/pass/type_pass/mod.rs
+++ b/src/pass/type_pass/mod.rs
@@ -138,6 +138,19 @@ impl TypeAnalysis {
         match expr {
             ExprNode::Primary(Primary::Integer {
                 sign: Signed::Unsigned,
+                width: IntegerWidth::ThirtyTwo,
+                value,
+            }) => {
+                let sign = Signed::Unsigned;
+                let width = IntegerWidth::ThirtyTwo;
+
+                Ok(ast::TypedExprNode::Primary(
+                    ast::Type::Integer(sign, width),
+                    crate::ast::Primary::Integer { sign, width, value },
+                ))
+            }
+            ExprNode::Primary(Primary::Integer {
+                sign: Signed::Unsigned,
                 width: IntegerWidth::Eight,
                 value,
             }) => {


### PR DESCRIPTION
# Introduction
This PR introduces width based integer types, `char`, `int` and `long`
# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
