### PR TITLE
Separate characters out into width

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,14 @@ char:   alphabetic
 identifier: alphabetic+
         ;
 
-type:   'char'
-        | 'int'
+type:   integer_type
         | 'void'
+        ;
+
+integer_type:
+        'char'
+        | 'int'
+        | 'long'
         ;
 
 alphabetic: [a-zA-Z]+

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ type:   integer_type
 
 integer_type:
         'char'
+        | 'short'
         | 'int'
         | 'long'
         ;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -146,6 +146,7 @@ pub enum Signed {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub enum IntegerWidth {
     Eight,
+    Sixteen,
     ThirtyTwo,
     SixtyFour,
 }
@@ -154,6 +155,7 @@ impl ByteSized for IntegerWidth {
     fn size(&self) -> usize {
         match self {
             Self::Eight => 1,
+            Self::Sixteen => 2,
             Self::ThirtyTwo => 4,
             Self::SixtyFour => 8,
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -147,6 +147,7 @@ pub enum Signed {
 pub enum IntegerWidth {
     Eight,
     ThirtyTwo,
+    SixtyFour,
 }
 
 impl ByteSized for IntegerWidth {
@@ -154,6 +155,7 @@ impl ByteSized for IntegerWidth {
         match self {
             Self::Eight => 1,
             Self::ThirtyTwo => 4,
+            Self::SixtyFour => 8,
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -143,15 +143,17 @@ pub enum Signed {
 }
 
 /// Represents valid integer bit widths.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub enum IntegerWidth {
     Eight,
+    ThirtyTwo,
 }
 
 impl ByteSized for IntegerWidth {
     fn size(&self) -> usize {
         match self {
             Self::Eight => 1,
+            Self::ThirtyTwo => 4,
         }
     }
 }
@@ -160,7 +162,6 @@ impl ByteSized for IntegerWidth {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
     Integer(Signed, IntegerWidth),
-    Char,
     Void,
     Func { return_type: Box<Type> },
 }
@@ -169,7 +170,6 @@ impl ByteSized for Type {
     fn size(&self) -> usize {
         match self {
             Self::Integer(_, iw) => iw.size(),
-            Self::Char => 1,
             Self::Void => 0,
             Self::Func { .. } => (usize::BITS / 8) as usize,
         }
@@ -180,11 +180,17 @@ impl ByteSized for Type {
 pub(crate) fn type_compatible(left: Type, right: Type, flow_left: bool) -> CompatibilityResult {
     match (left, right) {
         (lhs, rhs) if lhs == rhs => CompatibilityResult::Equivalent,
-        (Type::Integer(sign, width), Type::Char) => {
-            CompatibilityResult::WidenTo(Type::Integer(sign, width))
+        (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
+            if l_width != r_width && l_sign == r_sign =>
+        {
+            let widen_to_width = if l_width > r_width { l_width } else { r_width };
+            CompatibilityResult::WidenTo(Type::Integer(l_sign, widen_to_width))
         }
-        (Type::Char, Type::Integer(sign, width)) if !flow_left => {
-            CompatibilityResult::WidenTo(Type::Integer(sign, width))
+        (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
+            if l_width >= r_width && l_sign == r_sign && !flow_left =>
+        {
+            let widen_to_width = if l_width > r_width { l_width } else { r_width };
+            CompatibilityResult::WidenTo(Type::Integer(l_sign, widen_to_width))
         }
         _ => CompatibilityResult::Incompatible,
     }

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -87,12 +87,8 @@ fn codegen_statement(
     input: ast::TypedStmtNode,
 ) -> Result<Vec<String>, codegen::CodeGenerationErr> {
     match input {
-        ast::TypedStmtNode::Expression(expr) => allocator.allocate_then(|allocator, ret_val| {
-            Ok(vec![
-                codegen_expr(allocator, ret_val, expr),
-                codegen_printint(ret_val),
-            ])
-        }),
+        ast::TypedStmtNode::Expression(expr) => allocator
+            .allocate_then(|allocator, ret_val| Ok(vec![codegen_expr(allocator, ret_val, expr)])),
         ast::TypedStmtNode::Declaration(t, identifier) => {
             Ok(vec![codegen_global_symbol(t, &identifier)])
         }

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -314,6 +314,18 @@ fn codegen_expr(
             _,
             Primary::Integer {
                 sign: Signed::Unsigned,
+                width: IntegerWidth::ThirtyTwo,
+                value,
+            },
+        ) => {
+            let uc = core::convert::TryFrom::try_from(value)
+                .expect("value exceeds unsigned 32-bit integer");
+            codegen_constant_u32(ret_val, uc)
+        }
+        TypedExprNode::Primary(
+            _,
+            Primary::Integer {
+                sign: Signed::Unsigned,
                 width: IntegerWidth::Eight,
                 value,
             },
@@ -326,7 +338,7 @@ fn codegen_expr(
             _,
             Primary::Integer {
                 sign: Signed::Signed,
-                width: IntegerWidth::Eight,
+                width: _,
                 value: _,
             },
         ) => {
@@ -372,6 +384,15 @@ fn codegen_expr(
         }
         TypedExprNode::Division(_, lhs, rhs) => codegen_division(allocator, ret_val, lhs, rhs),
     }
+}
+
+fn codegen_constant_u32(ret_val: &mut SizedGeneralPurpose, constant: u32) -> Vec<String> {
+    vec![format!(
+        "\tmov{}\t${}, {}\n",
+        ret_val.operator_suffix(),
+        constant,
+        ret_val
+    )]
 }
 
 fn codegen_constant_u8(ret_val: &mut SizedGeneralPurpose, constant: u8) -> Vec<String> {

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -330,6 +330,18 @@ fn codegen_expr(
             _,
             Primary::Integer {
                 sign: Signed::Unsigned,
+                width: IntegerWidth::Sixteen,
+                value,
+            },
+        ) => {
+            let uc = core::convert::TryFrom::try_from(value)
+                .expect("value exceeds unsigned 32-bit integer");
+            codegen_constant_u16(ret_val, uc)
+        }
+        TypedExprNode::Primary(
+            _,
+            Primary::Integer {
+                sign: Signed::Unsigned,
                 width: IntegerWidth::Eight,
                 value,
             },
@@ -400,6 +412,15 @@ fn codegen_constant_u64(ret_val: &mut SizedGeneralPurpose, constant: u64) -> Vec
 }
 
 fn codegen_constant_u32(ret_val: &mut SizedGeneralPurpose, constant: u32) -> Vec<String> {
+    vec![format!(
+        "\tmov{}\t${}, {}\n",
+        ret_val.operator_suffix(),
+        constant,
+        ret_val
+    )]
+}
+
+fn codegen_constant_u16(ret_val: &mut SizedGeneralPurpose, constant: u16) -> Vec<String> {
     vec![format!(
         "\tmov{}\t${}, {}\n",
         ret_val.operator_suffix(),

--- a/src/codegen/machine/arch/x86_64/mod.rs
+++ b/src/codegen/machine/arch/x86_64/mod.rs
@@ -314,6 +314,14 @@ fn codegen_expr(
             _,
             Primary::Integer {
                 sign: Signed::Unsigned,
+                width: IntegerWidth::SixtyFour,
+                value,
+            },
+        ) => codegen_constant_u64(ret_val, value),
+        TypedExprNode::Primary(
+            _,
+            Primary::Integer {
+                sign: Signed::Unsigned,
                 width: IntegerWidth::ThirtyTwo,
                 value,
             },
@@ -384,6 +392,15 @@ fn codegen_expr(
         }
         TypedExprNode::Division(_, lhs, rhs) => codegen_division(allocator, ret_val, lhs, rhs),
     }
+}
+
+fn codegen_constant_u64(ret_val: &mut SizedGeneralPurpose, constant: u64) -> Vec<String> {
+    vec![format!(
+        "\tmov{}\t${}, {}\n",
+        ret_val.operator_suffix(),
+        constant,
+        ret_val
+    )]
 }
 
 fn codegen_constant_u32(ret_val: &mut SizedGeneralPurpose, constant: u32) -> Vec<String> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -81,14 +81,12 @@ fn declaration<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
     use crate::ast::Type;
 
     parcel::join(
-        whitespace_wrapped(
-            expect_str("int")
-                .map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::ThirtyTwo))
-                .or(|| {
-                    expect_str("char").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::Eight))
-                })
-                .or(|| expect_str("void").map(|_| Type::Void)),
-        ),
+        whitespace_wrapped(parcel::one_of(vec![
+            expect_str("long").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::SixtyFour)),
+            expect_str("int").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::ThirtyTwo)),
+            expect_str("char").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::Eight)),
+            expect_str("void").map(|_| Type::Void),
+        ])),
         whitespace_wrapped(identifier()),
     )
     .map(|(ty, id)| StmtNode::Declaration(ty, id))
@@ -320,12 +318,50 @@ fn number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
             width: IntegerWidth::ThirtyTwo,
             value: u64::from(num),
         }),
+        dec_u64().map(|num| Primary::Integer {
+            sign: Signed::Unsigned,
+            width: IntegerWidth::SixtyFour,
+            value: num,
+        }),
     ])
 }
 
 #[allow(clippy::redundant_closure)]
 fn identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], String> {
     parcel::one_or_more(alphabetic()).map(|chars| chars.into_iter().collect())
+}
+
+fn dec_u64<'a>() -> impl Parser<'a, &'a [(usize, char)], u64> {
+    move |input: &'a [(usize, char)]| {
+        let preparsed_input = input;
+        let res = parcel::one_or_more(digit(10))
+            .map(|digits| {
+                let vd: String = digits.into_iter().collect();
+                vd.parse::<u64>()
+            })
+            .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match {
+                span,
+                remainder,
+                inner: Ok(u),
+            }) => Ok(MatchStatus::Match {
+                span,
+                remainder,
+                inner: u,
+            }),
+
+            Ok(MatchStatus::Match {
+                span: _,
+                remainder: _,
+                inner: Err(_),
+            }) => Ok(MatchStatus::NoMatch(preparsed_input)),
+
+            Ok(MatchStatus::NoMatch(remainder)) => Ok(MatchStatus::NoMatch(remainder)),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 fn dec_u32<'a>() -> impl Parser<'a, &'a [(usize, char)], u32> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -84,6 +84,7 @@ fn declaration<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
         whitespace_wrapped(parcel::one_of(vec![
             expect_str("long").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::SixtyFour)),
             expect_str("int").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::ThirtyTwo)),
+            expect_str("short").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::Sixteen)),
             expect_str("char").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::Eight)),
             expect_str("void").map(|_| Type::Void),
         ])),

--- a/src/pass/type_pass/mod.rs
+++ b/src/pass/type_pass/mod.rs
@@ -133,29 +133,15 @@ impl TypeAnalysis {
         use crate::parser::ast::ExprNode;
         use crate::parser::ast::Primary;
 
-        use crate::ast::{IntegerWidth, Signed};
+        use crate::ast::Signed;
 
         match expr {
             ExprNode::Primary(Primary::Integer {
                 sign: Signed::Unsigned,
-                width: IntegerWidth::ThirtyTwo,
+                width,
                 value,
             }) => {
                 let sign = Signed::Unsigned;
-                let width = IntegerWidth::ThirtyTwo;
-
-                Ok(ast::TypedExprNode::Primary(
-                    ast::Type::Integer(sign, width),
-                    crate::ast::Primary::Integer { sign, width, value },
-                ))
-            }
-            ExprNode::Primary(Primary::Integer {
-                sign: Signed::Unsigned,
-                width: IntegerWidth::Eight,
-                value,
-            }) => {
-                let sign = Signed::Unsigned;
-                let width = IntegerWidth::Eight;
 
                 Ok(ast::TypedExprNode::Primary(
                     ast::Type::Integer(sign, width),

--- a/src/pass/type_pass/mod.rs
+++ b/src/pass/type_pass/mod.rs
@@ -138,6 +138,19 @@ impl TypeAnalysis {
         match expr {
             ExprNode::Primary(Primary::Integer {
                 sign: Signed::Unsigned,
+                width: IntegerWidth::ThirtyTwo,
+                value,
+            }) => {
+                let sign = Signed::Unsigned;
+                let width = IntegerWidth::ThirtyTwo;
+
+                Ok(ast::TypedExprNode::Primary(
+                    ast::Type::Integer(sign, width),
+                    crate::ast::Primary::Integer { sign, width, value },
+                ))
+            }
+            ExprNode::Primary(Primary::Integer {
+                sign: Signed::Unsigned,
                 width: IntegerWidth::Eight,
                 value,
             }) => {


### PR DESCRIPTION
# Introduction
This PR introduces width based integer types, `char`, `short`, `int` and `long`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
