### PR TITLE
Feature/pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,14 @@ identifier: alphabetic+
 call: identifier '(' expression? ')'
         ;
 
-type:   integer_type '*'
-        | 'void' '*'
-        | integer_type
-        | 'void'
-        
+type:   primitive_type '*'+
+        | primitive_type
         ;
+
+primitive_type: integer_type
+        | 'void'
+        ;
+
 
 integer_type:
         'char'

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ relational: addition ( ( '<' | '<=' | '>' | '>=' ) addition )*
 addition: multiplication ( ( '-' | '+' ) multiplication )* 
         ;
 
-multiplication: primary ( ( '/' | '*' ) primary )* 
+multiplication: call ( ( '/' | '*' ) call )* 
         ;
 
-primary: call
-        | identifier
+primary: identifier
         | integer
         ;
 
@@ -81,8 +80,11 @@ identifier: alphabetic+
 call: identifier '(' expression? ')'
         ;
 
-type:   integer_type
+type:   integer_type '*'
+        | 'void' '*'
+        | integer_type
         | 'void'
+        
         ;
 
 integer_type:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ call: identifier '(' expression? ')'
         ;
 
 prefix_expression: '*' prefix_expression
-        | '&' prefix_expression
+        | '&' identifier
         | primary
         ;
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ addition: multiplication ( ( '-' | '+' ) multiplication )*
 multiplication: call ( ( '/' | '*' ) call )* 
         ;
 
+call: identifier '(' expression? ')'
+        | prefix_expression
+        ;
+
+prefix_expression: '*' prefix_expression
+        | '&' prefix_expression
+        | primary
+        ;
+
 primary: identifier
         | integer
         ;
@@ -75,9 +84,6 @@ char:   alphabetic
         ;
 
 identifier: alphabetic+
-        ;
-
-call: identifier '(' expression? ')'
         ;
 
 type:   primitive_type '*'+

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -88,6 +88,10 @@ pub enum TypedExprNode {
     Division(Type, Box<TypedExprNode>, Box<TypedExprNode>),
     Addition(Type, Box<TypedExprNode>, Box<TypedExprNode>),
     Multiplication(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+
+    // Pointer Operations
+    Ref(Type, String),
+    Deref(Type, Box<TypedExprNode>),
 }
 
 impl Typed for TypedExprNode {
@@ -104,7 +108,9 @@ impl Typed for TypedExprNode {
             | TypedExprNode::Subtraction(t, _, _)
             | TypedExprNode::Division(t, _, _)
             | TypedExprNode::Addition(t, _, _)
-            | TypedExprNode::Multiplication(t, _, _) => t.clone(),
+            | TypedExprNode::Multiplication(t, _, _)
+            | TypedExprNode::Ref(t, _)
+            | TypedExprNode::Deref(t, _) => t.clone(),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -124,12 +124,11 @@ impl Typed for Primary {
     fn r#type(&self) -> Type {
         match self {
             Primary::Integer {
-                sign: Signed::Unsigned,
-                width: IntegerWidth::Eight,
+                sign,
+                width,
                 value: _,
-            } => Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+            } => Type::Integer(*sign, *width),
             Primary::Identifier(ty, _) => ty.clone(),
-            _ => panic!("unknown type"),
         }
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -88,6 +88,10 @@ pub enum ExprNode {
     Division(Box<ExprNode>, Box<ExprNode>),
     Addition(Box<ExprNode>, Box<ExprNode>),
     Multiplication(Box<ExprNode>, Box<ExprNode>),
+
+    // Pointer Operations
+    Ref(String),
+    Deref(Box<ExprNode>),
 }
 
 /// Primary represents a primitive type within the ast.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -310,6 +310,8 @@ fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
 fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
     whitespace_wrapped(expect_character('*'))
         .and_then(|_| prefix_expression())
+        .map(Box::new)
+        .map(ExprNode::Deref)
         .or(|| {
             whitespace_wrapped(expect_character('&'))
                 .and_then(|_| identifier())

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -342,6 +342,41 @@ fn r#type<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], crate::ast::Type
     use crate::ast::Type;
 
     whitespace_wrapped(parcel::one_of(vec![
+        expect_str("long")
+            .and_then(|_| whitespace_wrapped(expect_character('*')))
+            .map(|_| {
+                Type::Pointer(Box::new(Type::Integer(
+                    Signed::Unsigned,
+                    IntegerWidth::SixtyFour,
+                )))
+            }),
+        expect_str("int")
+            .and_then(|_| whitespace_wrapped(expect_character('*')))
+            .map(|_| {
+                Type::Pointer(Box::new(Type::Integer(
+                    Signed::Unsigned,
+                    IntegerWidth::ThirtyTwo,
+                )))
+            }),
+        expect_str("short")
+            .and_then(|_| whitespace_wrapped(expect_character('*')))
+            .map(|_| {
+                Type::Pointer(Box::new(Type::Integer(
+                    Signed::Unsigned,
+                    IntegerWidth::Sixteen,
+                )))
+            }),
+        expect_str("char")
+            .and_then(|_| whitespace_wrapped(expect_character('*')))
+            .map(|_| {
+                Type::Pointer(Box::new(Type::Integer(
+                    Signed::Unsigned,
+                    IntegerWidth::Eight,
+                )))
+            }),
+        expect_str("void")
+            .and_then(|_| whitespace_wrapped(expect_character('*')))
+            .map(|_| Type::Pointer(Box::new(Type::Void))),
         expect_str("long").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::SixtyFour)),
         expect_str("int").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::ThirtyTwo)),
         expect_str("short").map(|_| Type::Integer(Signed::Unsigned, IntegerWidth::Sixteen)),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -55,12 +55,12 @@ fn compound_statements<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Com
 }
 
 fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
-    semicolon_terminated_statement(expression().map(StmtNode::Expression))
-        .or(|| semicolon_terminated_statement(declaration()))
+    semicolon_terminated_statement(declaration())
         .or(|| semicolon_terminated_statement(assignment()))
         .or(if_statement)
         .or(while_statement)
         .or(for_statement)
+        .or(|| semicolon_terminated_statement(expression().map(StmtNode::Expression)))
         .or(|| semicolon_terminated_statement(return_statement()))
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -304,7 +304,18 @@ fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
         )),
     )
     .map(|(id, expr)| ExprNode::FunctionCall(id, expr.map(Box::new)))
-    .or(primary)
+    .or(prefix_expression)
+}
+
+fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+    whitespace_wrapped(expect_character('*'))
+        .and_then(|_| prefix_expression())
+        .or(|| {
+            whitespace_wrapped(expect_character('&'))
+                .and_then(|_| identifier())
+                .map(ExprNode::Ref)
+        })
+        .or(primary)
 }
 
 fn primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -490,7 +490,7 @@ fn codegen_reference(ret: &mut SizedGeneralPurpose, identifier: &str) -> Vec<Str
 
 fn codegen_deref(ret: &mut SizedGeneralPurpose, _: ast::Type) -> Vec<String> {
     vec![format!(
-        "\tmov{}\t%({}(), {}\n",
+        "\tmov{}\t(%{}), %{}\n",
         ret.operator_suffix(),
         ret.id(),
         ret.id()

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -438,6 +438,13 @@ fn codegen_expr(
             codegen_multiplication(allocator, ret_val, lhs, rhs)
         }
         TypedExprNode::Division(_, lhs, rhs) => codegen_division(allocator, ret_val, lhs, rhs),
+        TypedExprNode::Ref(_, identifier) => codegen_reference(ret_val, &identifier),
+        TypedExprNode::Deref(ty, expr) => {
+            flattenable_instructions!(
+                codegen_expr(allocator, ret_val, *expr),
+                codegen_deref(ret_val, ty),
+            )
+        }
     }
 }
 
@@ -474,6 +481,19 @@ fn codegen_constant_u8(ret_val: &mut SizedGeneralPurpose, constant: u8) -> Vec<S
         ret_val.operator_suffix(),
         constant,
         ret_val
+    )]
+}
+
+fn codegen_reference(ret: &mut SizedGeneralPurpose, identifier: &str) -> Vec<String> {
+    vec![format!("\tleaq\t{}(%rip), %{}\n", identifier, ret.id())]
+}
+
+fn codegen_deref(ret: &mut SizedGeneralPurpose, _: ast::Type) -> Vec<String> {
+    vec![format!(
+        "\tmov{}\t%({}(), {}\n",
+        ret.operator_suffix(),
+        ret.id(),
+        ret.id()
     )]
 }
 

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -158,7 +158,6 @@ impl TypeAnalysis {
             crate::parser::ast::StmtNode::Assignment(id, expr) => {
                 let expr = self.analyze_expression(expr)?;
 
-                println!("{:?}", &expr);
                 self.scopes
                     .lookup(&id)
                     .map(|var_type| type_compatible(&var_type, &expr.r#type(), true))


### PR DESCRIPTION
# Introduction
This PR introduces support for pointers along with the `*` and `&` operators.

```c
int main() {
    int x;
    int *y;
    int z;

    x = 5;
    y = &x;
    z = *y;

    return z;
}
```
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
