### PR TITLE
Pointer arthmetic

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -158,6 +158,7 @@ pub trait ByteSized {
 pub enum CompatibilityResult {
     Equivalent,
     WidenTo(Type),
+    Scale(Type),
     Incompatible,
 }
 
@@ -242,22 +243,33 @@ impl Type {
     }
 }
 
-/// Evaluates type compatiblity for a given binary pair of types.
-pub(crate) fn type_compatible(left: &Type, right: &Type, flow_left: bool) -> CompatibilityResult {
-    match (left, right) {
-        (lhs, rhs) if lhs == rhs => CompatibilityResult::Equivalent,
-        (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
-            if l_width != r_width && l_sign == r_sign && !flow_left =>
-        {
-            let widen_to_width = if l_width > r_width { l_width } else { r_width };
-            CompatibilityResult::WidenTo(Type::Integer(*l_sign, *widen_to_width))
+pub trait TypeCompatibility {
+    type Output;
+    type Rhs;
+
+    fn type_compatible(&self, right: &Self::Rhs, flow_left: bool) -> Self::Output;
+}
+
+impl TypeCompatibility for Type {
+    type Output = CompatibilityResult;
+    type Rhs = Type;
+
+    fn type_compatible(&self, right: &Self::Rhs, flow_left: bool) -> Self::Output {
+        match (self, right) {
+            (lhs, rhs) if lhs == rhs => CompatibilityResult::Equivalent,
+            (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
+                if l_width != r_width && l_sign == r_sign && !flow_left =>
+            {
+                let widen_to_width = if l_width > r_width { l_width } else { r_width };
+                CompatibilityResult::WidenTo(Type::Integer(*l_sign, *widen_to_width))
+            }
+            (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
+                if l_width >= r_width && l_sign == r_sign && flow_left =>
+            {
+                let widen_to_width = if l_width > r_width { l_width } else { r_width };
+                CompatibilityResult::WidenTo(Type::Integer(*l_sign, *widen_to_width))
+            }
+            _ => CompatibilityResult::Incompatible,
         }
-        (Type::Integer(l_sign, l_width), Type::Integer(r_sign, r_width))
-            if l_width >= r_width && l_sign == r_sign && flow_left =>
-        {
-            let widen_to_width = if l_width > r_width { l_width } else { r_width };
-            CompatibilityResult::WidenTo(Type::Integer(*l_sign, *widen_to_width))
-        }
-        _ => CompatibilityResult::Incompatible,
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -103,6 +103,7 @@ pub enum TypedExprNode {
     // Pointer Operations
     Ref(Type, String),
     Deref(Type, Box<TypedExprNode>),
+    ScaleBy(Type, Box<TypedExprNode>),
 }
 
 impl Typed for TypedExprNode {
@@ -121,7 +122,8 @@ impl Typed for TypedExprNode {
             | TypedExprNode::Addition(t, _, _)
             | TypedExprNode::Multiplication(t, _, _)
             | TypedExprNode::Ref(t, _)
-            | TypedExprNode::Deref(t, _) => t.clone(),
+            | TypedExprNode::Deref(t, _)
+            | TypedExprNode::ScaleBy(t, _) => t.clone(),
         }
     }
 }
@@ -269,6 +271,8 @@ impl TypeCompatibility for Type {
                 let widen_to_width = if l_width > r_width { l_width } else { r_width };
                 CompatibilityResult::WidenTo(Type::Integer(*l_sign, *widen_to_width))
             }
+            (Type::Pointer(ty), Type::Integer(_, _)) => CompatibilityResult::Scale(*ty.clone()),
+
             _ => CompatibilityResult::Incompatible,
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -60,8 +60,8 @@ fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
         .or(if_statement)
         .or(while_statement)
         .or(for_statement)
-        .or(|| semicolon_terminated_statement(expression().map(StmtNode::Expression)))
         .or(|| semicolon_terminated_statement(return_statement()))
+        .or(|| semicolon_terminated_statement(expression().map(StmtNode::Expression)))
 }
 
 fn semicolon_terminated_statement<'a, P>(
@@ -328,12 +328,12 @@ fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
 }
 
 fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
-    whitespace_wrapped(expect_character('*'))
+    expect_character('*')
         .and_then(|_| prefix_expression())
         .map(Box::new)
         .map(ExprNode::Deref)
         .or(|| {
-            whitespace_wrapped(expect_character('&'))
+            expect_character('&')
                 .and_then(|_| identifier())
                 .map(ExprNode::Ref)
         })

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -116,8 +116,12 @@ fn codegen_statement(
     input: ast::TypedStmtNode,
 ) -> Result<Vec<String>, codegen::CodeGenerationErr> {
     match input {
-        ast::TypedStmtNode::Expression(expr) => allocator
-            .allocate_then(|allocator, ret_val| Ok(vec![codegen_expr(allocator, ret_val, expr)])),
+        ast::TypedStmtNode::Expression(expr) => allocator.allocate_then(|allocator, ret_val| {
+            Ok(vec![
+                codegen_expr(allocator, ret_val, expr),
+                codegen_printint(ret_val),
+            ])
+        }),
         ast::TypedStmtNode::Declaration(ast::Declaration(ty, identifiers)) => {
             let var_decls = identifiers
                 .iter()
@@ -310,7 +314,7 @@ pub fn codegen_function_postamble(identifier: &str) -> Vec<String> {
 }
 
 fn codegen_global_symbol(kind: &Type, identifier: &str) -> Vec<String> {
-    const ALIGNMENT: usize = 16;
+    const ALIGNMENT: usize = 2;
     let reserve_bytes = kind.size();
 
     vec![format!(

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -195,7 +195,7 @@ impl TypeAnalysis {
                         ast::CompatibilityResult::Incompatible => {
                             Err(format!("invalid type: ({:?})", expr.r#type()))
                         }
-                        ast::CompatibilityResult::Scale(_) => todo!(),
+                        ast::CompatibilityResult::Scale(t) => Ok(t),
                     })
                     .map(|_| ast::TypedStmtNode::Assignment(id, expr))
             }
@@ -390,7 +390,11 @@ impl TypeAnalysis {
             ast::CompatibilityResult::Equivalent => Some((lhs.r#type(), lhs, rhs)),
             ast::CompatibilityResult::WidenTo(ty) => Some((ty, lhs, rhs)),
             ast::CompatibilityResult::Incompatible => None,
-            ast::CompatibilityResult::Scale(_) => todo!(),
+            ast::CompatibilityResult::Scale(ty) => Some((
+                ty.clone(),
+                lhs,
+                ast::TypedExprNode::ScaleBy(ty, Box::new(rhs)),
+            )),
         }
     }
 }


### PR DESCRIPTION
# Introduction
Introduce pointer arithmetic operations along with a ScaleBy type comparison.

```c
int   c;
int   d;
int  *e;

int main() {
  c = 12;
  d = 18;
  e = &d;

  e = e + 3;

  return *e;
}
```
```
vscode ➜ /workspaces/mossy (refactor-improve-type-compatibility-checks ✗) $ ./a.out 
vscode ➜ /workspaces/mossy (refactor-improve-type-compatibility-checks ✗) $ echo $?
12
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
