### PR TITLE
Feature/group expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ prefix_expression: '*' prefix_expression
 
 primary: identifier
         | integer_constant
+        | grouping 
         ;
 
 char:   alphabetic
         ;
 
+grouping: '(' expression ')'
+        ;
 
 identifier_list: identifier
         | identifier ',' identifier_list

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -98,6 +98,8 @@ pub enum ExprNode {
     // Pointer Operations
     Ref(String),
     Deref(Box<ExprNode>),
+
+    Grouping(Box<ExprNode>),
 }
 
 /// Primary represents a primitive type within the ast.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -342,6 +342,18 @@ fn primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
     identifier()
         .map(|id| ExprNode::Primary(Primary::Identifier(id)))
         .or(|| number().map(ExprNode::Primary))
+        .or(grouping)
+}
+
+fn grouping<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+    whitespace_wrapped(expect_character('('))
+        .and_then(|_| {
+            parcel::left(parcel::join(
+                expression(),
+                whitespace_wrapped(expect_character(')')),
+            ))
+        })
+        .map(|expr| ExprNode::Grouping(Box::new(expr)))
 }
 
 fn number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
@@ -630,6 +642,35 @@ mod tests {
                     ExprNode::Primary(Primary::Identifier("y".to_string())),
                     primary_expr!(5)
                 )
+            ),
+        )]));
+
+        assert_eq!(&expected_result, &res);
+    }
+
+    #[test]
+    fn should_parse_grouping_expressions_in_correct_precedence() {
+        use parcel::Parser;
+
+        let input: Vec<(usize, char)> = "{
+    2 * (3 + 4);
+}"
+        .chars()
+        .enumerate()
+        .collect();
+        let res = crate::parser::compound_statements()
+            .parse(&input)
+            .map(|ms| ms.unwrap());
+
+        let expected_result = Ok(CompoundStmts::new(vec![StmtNode::Expression(
+            factor_expr!(
+                primary_expr!(2),
+                '*',
+                ExprNode::Grouping(Box::new(term_expr!(
+                    primary_expr!(3),
+                    '+',
+                    primary_expr!(4)
+                )))
             ),
         )]));
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -569,6 +569,12 @@ mod tests {
         };
     }
 
+    macro_rules! grouping_expr {
+        ($value:expr) => {
+            $crate::parser::ast::ExprNode::Grouping(Box::new($value))
+        };
+    }
+
     use crate::parser::ast::*;
 
     #[test]
@@ -666,11 +672,7 @@ mod tests {
             factor_expr!(
                 primary_expr!(2),
                 '*',
-                ExprNode::Grouping(Box::new(term_expr!(
-                    primary_expr!(3),
-                    '+',
-                    primary_expr!(4)
-                )))
+                grouping_expr!(term_expr!(primary_expr!(3), '+', primary_expr!(4)))
             ),
         )]));
 

--- a/src/stage/ast/mod.rs
+++ b/src/stage/ast/mod.rs
@@ -106,6 +106,8 @@ pub enum TypedExprNode {
     Ref(Type, String),
     Deref(Type, Box<TypedExprNode>),
     ScaleBy(Type, Box<TypedExprNode>),
+
+    Grouping(Type, Box<TypedExprNode>),
 }
 
 impl Typed for TypedExprNode {
@@ -127,7 +129,8 @@ impl Typed for TypedExprNode {
             | TypedExprNode::Multiplication(ty, _, _)
             | TypedExprNode::Ref(ty, _)
             | TypedExprNode::Deref(ty, _)
-            | TypedExprNode::ScaleBy(ty, _) => ty.clone(),
+            | TypedExprNode::ScaleBy(ty, _)
+            | TypedExprNode::Grouping(ty, _) => ty.clone(),
         }
     }
 }

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -483,6 +483,7 @@ fn codegen_expr(
             let scale_by_size = ty.size();
             codegen_scaleby(allocator, ret_val, scale_by_size, lhs)
         }
+        TypedExprNode::Grouping(_, expr) => codegen_expr(allocator, ret_val, *expr),
     }
 }
 

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -422,3 +422,97 @@ impl TypeAnalysis {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::ast;
+    use crate::stage::{
+        self,
+        ast::{IntegerWidth, Signed, Type, TypedExprNode},
+    };
+
+    #[test]
+    fn test_grouping_assigns_correct_type() {
+        let analyzer = super::TypeAnalysis::default();
+        let pre_typed_ast =
+            ast::ExprNode::Grouping(Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
+                sign: Signed::Unsigned,
+                width: IntegerWidth::Eight,
+                value: 1,
+            })));
+
+        let typed_ast = analyzer.analyze_expression(pre_typed_ast);
+        let expected = TypedExprNode::Grouping(
+            Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+            Box::new(TypedExprNode::Primary(
+                Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                stage::ast::Primary::Integer {
+                    sign: Signed::Unsigned,
+                    width: IntegerWidth::Eight,
+                    value: 1,
+                },
+            )),
+        );
+
+        assert_eq!(Ok(expected), typed_ast);
+
+        // Preserves complex order
+
+        let pre_typed_ast = ast::ExprNode::Grouping(Box::new(ast::ExprNode::Multiplication(
+            Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
+                sign: Signed::Unsigned,
+                width: IntegerWidth::Eight,
+                value: 2,
+            })),
+            Box::new(ast::ExprNode::Addition(
+                Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
+                    sign: Signed::Unsigned,
+                    width: IntegerWidth::Eight,
+                    value: 3,
+                })),
+                Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
+                    sign: Signed::Unsigned,
+                    width: IntegerWidth::Eight,
+                    value: 4,
+                })),
+            )),
+        )));
+
+        let typed_ast = analyzer.analyze_expression(pre_typed_ast);
+        let expected = TypedExprNode::Grouping(
+            Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+            Box::new(TypedExprNode::Multiplication(
+                Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                Box::new(TypedExprNode::Primary(
+                    Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                    stage::ast::Primary::Integer {
+                        sign: Signed::Unsigned,
+                        width: IntegerWidth::Eight,
+                        value: 2,
+                    },
+                )),
+                Box::new(TypedExprNode::Addition(
+                    Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                    Box::new(TypedExprNode::Primary(
+                        Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                        stage::ast::Primary::Integer {
+                            sign: Signed::Unsigned,
+                            width: IntegerWidth::Eight,
+                            value: 3,
+                        },
+                    )),
+                    Box::new(TypedExprNode::Primary(
+                        Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                        stage::ast::Primary::Integer {
+                            sign: Signed::Unsigned,
+                            width: IntegerWidth::Eight,
+                            value: 4,
+                        },
+                    )),
+                )),
+            )),
+        );
+
+        assert_eq!(Ok(expected), typed_ast);
+    }
+}

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -259,7 +259,10 @@ impl TypeAnalysis {
                 })
                 .ok_or_else(|| "invalid type".to_string()),
 
-            ExprNode::Grouping(_) => todo!(),
+            ExprNode::Grouping(expr) => self
+                .analyze_expression(*expr)
+                .map(|ty_expr| (ty_expr.r#type(), ty_expr))
+                .map(|(ty, expr)| ast::TypedExprNode::Grouping(ty, Box::new(expr))),
 
             ExprNode::FunctionCall(identifier, args) => {
                 let args = args.map(|arg| self.analyze_expression(*arg).unwrap());

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -259,6 +259,8 @@ impl TypeAnalysis {
                 })
                 .ok_or_else(|| "invalid type".to_string()),
 
+            ExprNode::Grouping(_) => todo!(),
+
             ExprNode::FunctionCall(identifier, args) => {
                 let args = args.map(|arg| self.analyze_expression(*arg).unwrap());
 


### PR DESCRIPTION
# Introduction
This PR adds grouping expressions allowing for expressions such as the following.

```c
int x;
int y;
int main() {
    // x == 10
    x = 2 * 3 + 4;

    // y == 14
    y = 2 * (3 + 4);

    return 0;
}
```
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
