### PR TITLE
Small change to fix debug formatting output in binary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn compile(source: &str) -> RuntimeResult<String> {
         })
         .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))?
         .map(|insts| insts.into_iter().collect::<String>())
-        .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))
+        .map_err(RuntimeError::Undefined)
 }
 
 fn main() {
@@ -129,7 +129,7 @@ fn main() {
         }
 
         Err(RuntimeError::Undefined(e)) => {
-            println!("{}\n{}", e, &help_string);
+            println!("error: {}", e);
             std::process::exit(RuntimeError::Undefined(e).exit_code())
         }
     }


### PR DESCRIPTION
# Introduction
Small change in the main.rs binary to convert error output from debug to display formatted, effectively dropping the `"`.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
