### PR TITLE
Update scales and arrays to use reference types

### DIFF
--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -1012,25 +1012,33 @@ mod tests {
         let index_expression = TypedStmtNode::Expression(ast::TypedExprNode::Deref(
             Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
             Box::new(ast::TypedExprNode::Addition(
-                Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                Type::Integer(Signed::Unsigned, IntegerWidth::Eight).pointer_to(),
                 Box::new(ast::TypedExprNode::Ref(
                     Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
                     "x".to_string(),
                 )),
-                Box::new(TypedExprNode::Primary(
+                Box::new(TypedExprNode::ScaleBy(
                     Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
-                    Primary::Integer {
-                        sign: Signed::Unsigned,
-                        width: IntegerWidth::Eight,
-                        value: 1,
-                    },
+                    Box::new(TypedExprNode::Grouping(
+                        Type::Integer(Signed::Unsigned, IntegerWidth::SixtyFour),
+                        Box::new(TypedExprNode::Primary(
+                            Type::Integer(Signed::Unsigned, IntegerWidth::Eight),
+                            Primary::Integer {
+                                sign: Signed::Unsigned,
+                                width: IntegerWidth::Eight,
+                                value: 1,
+                            },
+                        )),
+                    )),
                 )),
             )),
         ));
 
         assert_eq!(
             Ok(vec!["\tleaq\tx(%rip), %r14
+\tmovq\t$1, %r13
 \tmovq\t$1, %r15
+\timulq\t%r13, %r15
 \taddb\t%r14b, %r15b
 \tmovb\t(%r15), %r15b
 "

--- a/src/stage/type_check/scopes.rs
+++ b/src/stage/type_check/scopes.rs
@@ -3,12 +3,11 @@ use crate::stage::ast::Type;
 #[derive(Debug, Clone)]
 pub struct DeclarationMetadata {
     pub r#type: Type,
-    pub size: usize,
 }
 
 impl DeclarationMetadata {
-    pub fn new(ty: Type, size: usize) -> Self {
-        Self { r#type: ty, size }
+    pub fn new(ty: Type) -> Self {
+        Self { r#type: ty }
     }
 }
 
@@ -41,14 +40,7 @@ impl ScopeStack {
     pub fn define_mut(&mut self, id: &str, ty: Type) {
         self.scopes
             .last_mut()
-            .map(|scope| scope.insert(id.to_string(), DeclarationMetadata::new(ty, 1)));
-    }
-
-    /// Defines a new variable in place.
-    pub fn define_sized_mut(&mut self, id: &str, ty: Type, size: usize) {
-        self.scopes
-            .last_mut()
-            .map(|scope| scope.insert(id.to_string(), DeclarationMetadata::new(ty, size)));
+            .map(|scope| scope.insert(id.to_string(), DeclarationMetadata::new(ty)));
     }
 
     /// looks up variable in place.


### PR DESCRIPTION
# Introduction
Updates arrays to use pointer types for clarity in the typechecker.
# Linked Issues
resolves #96 

blocks #95 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
