### PR TITLE
Bugfix/string literal whitespace and escape sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ statement:
         | return_stmt
         ;
 
-var_declaration: type_declarator  '[' integer_literal ']' ';'
+var_declaration: type_declarator  '[' digit ']' ';'
         | type_declarator identifier_list ';'
         ;
 
@@ -93,11 +93,11 @@ postfix_expression: primary
 
 primary: identifier
         | string_literal
-        | integer_literal
+        | digit
         | grouping 
         ;
 
-char:   alphabetic
+char:   ascii_alphabetic
         ;
 
 grouping: '(' expression ')'
@@ -107,7 +107,7 @@ identifier_list: identifier
         | identifier ',' identifier_list
         ;
 
-identifier: alphabetic+
+identifier: ( ascii_alphabetic | numeric | '_' )+
         ;
 
 type_declarator:   type_specifier optional_pointer
@@ -127,18 +127,21 @@ type_specifier: 'char'
         | 'void'
         ;
 
-string_literal: '"' (alphabetic | integer_literal | whitespace )* '"'
+string_literal: '"' ( ascii_alphanumeric | ' ' | ascii_whitespace | ascii_control | '\"')* '"'
 
-integer_literal:  [0-9]*;
+digit:  [0-9]*;
 
 ascii_alphabetic: [a-zA-Z]+;
 
 ascii_alphanumeric: alphabetic
-        | integer_literal
+        | digit
         ;
 
-whitespace: ' '
-        | '\t'
-        | '\n'
+ascii_whitespace: *DEVNOTE: ascii check spec*
         ;
+
+ascii_control: *DEVNOTE: ascii check spec*
+        ;
+
+space: ' '
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ digit:  [0-9]*;
 
 ascii_alphabetic: [a-zA-Z]+;
 
-ascii_alphanumeric: alphabetic
+ascii_alphanumeric: ascii_alphabetic
         | digit
         ;
 

--- a/README.md
+++ b/README.md
@@ -127,10 +127,18 @@ type_specifier: 'char'
         | 'void'
         ;
 
-string_literal: '"' (alphabetic | integer_literal) '"'
+string_literal: '"' (alphabetic | integer_literal | whitespace )* '"'
 
 integer_literal:  [0-9]*;
 
+ascii_alphabetic: [a-zA-Z]+;
 
-alphabetic: [a-zA-Z]+;
+ascii_alphanumeric: alphabetic
+        | integer_literal
+        ;
+
+whitespace: ' '
+        | '\t'
+        | '\n'
+        ;
 ```

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -387,10 +387,10 @@ fn postfix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Expr
 }
 
 fn primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
-    identifier()
-        .map(|id| ExprNode::Primary(Primary::Identifier(id)))
+    number()
+        .map(ExprNode::Primary)
         .or(|| string_literal().map(ExprNode::Primary))
-        .or(|| number().map(ExprNode::Primary))
+        .or(|| identifier().map(|id| ExprNode::Primary(Primary::Identifier(id))))
         .or(grouping)
 }
 
@@ -492,7 +492,7 @@ fn unsigned_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary
 }
 
 fn identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], String> {
-    parcel::one_or_more(ascii_alphabetic().or(|| expect_character('_')))
+    parcel::one_or_more(ascii_alphanumeric().or(|| expect_character('_')))
         .map(|chars| chars.into_iter().collect())
 }
 
@@ -667,10 +667,6 @@ numeric_type_parser!(
     unsigned, dec_u32, u32,
     unsigned, dec_u64, u64,
 );
-
-fn ascii_alphabetic<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
-    any_character().predicate(|c| c.is_ascii_alphabetic())
-}
 
 fn ascii_whitespace<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
     any_character().predicate(|c| c.is_ascii_whitespace())

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -492,7 +492,8 @@ fn unsigned_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary
 }
 
 fn identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], String> {
-    parcel::one_or_more(ascii_alphabetic()).map(|chars| chars.into_iter().collect())
+    parcel::one_or_more(ascii_alphabetic().or(|| expect_character('_')))
+        .map(|chars| chars.into_iter().collect())
 }
 
 fn type_declarator<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Type> {


### PR DESCRIPTION
# Introduction
Fix string literal parsing to allow all ascii and escaped characters.

Additionally this starts expanding allowable characters in identifiers.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
