### PR TITLE
Implement a basic Integer Type ranking system

### DIFF
--- a/src/stage/ast/mod.rs
+++ b/src/stage/ast/mod.rs
@@ -22,6 +22,13 @@ macro_rules! generate_type_specifier {
             $crate::stage::ast::IntegerWidth::Eight
         )
     };
+    (i16) => {
+        generate_type_specifier!(
+            integer,
+            $crate::stage::ast::Signed::Signed,
+            $crate::stage::ast::IntegerWidth::Sixteen
+        )
+    };
     (u64) => {
         generate_type_specifier!(
             integer,

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -85,10 +85,11 @@ fn calculate_satisfying_integer_size_from_rank(lhs: usize, rhs: usize) -> usize 
     let max = core::cmp::max(lhs, rhs);
     let min = core::cmp::min(lhs, rhs);
 
-    match (max, min) {
-        // promote to next largest signed integer
-        _ if !is_even(max) && (max - min) == 1 => max + 1,
-        _ => max,
+    // promote to next largest signed integer
+    if !is_even(max) && (max - min) == 1 {
+        max + 1
+    } else {
+        max
     }
 }
 

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -128,14 +128,10 @@ impl TypeCompatibility for ast::Type {
                         calculate_satisfying_integer_size_from_rank(lhs_rank, rhs_rank);
 
                     core::convert::TryFrom::try_from(adjusted_rank)
-                        .map(
-                            |Integer {
-                                 signed: sign,
-                                 width,
-                             }| {
-                                CompatibilityResult::WidenTo(Type::Integer(sign, width))
-                            },
-                        )
+                        .map(|Integer { signed, width }| (signed, width))
+                        .map(|(sign, width)| {
+                            CompatibilityResult::WidenTo(Type::Integer(sign, width))
+                        })
                         .unwrap_or(CompatibilityResult::Incompatible)
                 }
             }

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -771,6 +771,9 @@ mod tests {
     #[test]
     fn should_assign_nearest_ranked_size() {
         let analyzer = super::TypeAnalysis::default();
+
+        // promotion of integer size
+
         let pre_typed_ast = ast::ExprNode::Addition(
             Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
                 sign: Signed::Unsigned,
@@ -799,6 +802,44 @@ mod tests {
                 generate_type_specifier!(i8),
                 stage::ast::Primary::Integer {
                     sign: Signed::Signed,
+                    width: IntegerWidth::Eight,
+                    value: pad_to_le_64bit_array!(1u8),
+                },
+            )),
+        );
+
+        assert_eq!(Ok(expected), typed_ast);
+
+        // equivalent size
+
+        let pre_typed_ast = ast::ExprNode::Addition(
+            Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
+                sign: Signed::Unsigned,
+                width: IntegerWidth::Eight,
+                value: pad_to_le_64bit_array!(1u8),
+            })),
+            Box::new(ast::ExprNode::Primary(ast::Primary::Integer {
+                sign: Signed::Unsigned,
+                width: IntegerWidth::Eight,
+                value: pad_to_le_64bit_array!(1u8),
+            })),
+        );
+
+        let typed_ast = analyzer.analyze_expression(pre_typed_ast);
+        let expected = TypedExprNode::Addition(
+            generate_type_specifier!(u8),
+            Box::new(TypedExprNode::Primary(
+                generate_type_specifier!(u8),
+                stage::ast::Primary::Integer {
+                    sign: Signed::Unsigned,
+                    width: IntegerWidth::Eight,
+                    value: pad_to_le_64bit_array!(1u8),
+                },
+            )),
+            Box::new(TypedExprNode::Primary(
+                generate_type_specifier!(u8),
+                stage::ast::Primary::Integer {
+                    sign: Signed::Unsigned,
                     width: IntegerWidth::Eight,
                     value: pad_to_le_64bit_array!(1u8),
                 },


### PR DESCRIPTION
# Introduction
This PR extends the type comparison system by assigning a rank score to all integer data types allowing for rules to be assigned to how these are promoted.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
