### PR TITLE
Assignment expressions now return their value

### DIFF
--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -479,12 +479,10 @@ fn codegen_expr(
         }
 
         ast::TypedExprNode::IdentifierAssignment(ty, identifier, expr) => {
-            allocator.allocate_then(|allocator, ret_val| {
-                flattenable_instructions!(
-                    codegen_expr(allocator, ret_val, *expr),
-                    codegen_store_global(ty, ret_val, &identifier),
-                )
-            })
+            flattenable_instructions!(
+                codegen_expr(allocator, ret_val, *expr),
+                codegen_store_global(ty, ret_val, &identifier),
+            )
         }
         TypedExprNode::DerefAssignment(_, lhs, rhs) => {
             allocator.allocate_then(|allocator, rhs_ret_val| {


### PR DESCRIPTION
# Introduction
Identifier assignments weren't previously returning their value correctly. This PR fixes this behavior.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
