### PR TITLE
implement_preincrement operator for identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ call: identifier '(' expression? ')'
 
 prefix_expression: '*' prefix_expression
         | '&' identifier
+        | '++' prefix_expression
+        | '--' prefix_expression
         | '!' prefix_expression
         | '-' prefix_expression
         | '~' prefix_expression

--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ prefix_expression: '*' prefix_expression
         | '!' prefix_expression
         | '-' prefix_expression
         | '~' prefix_expression
+        | post_increment_decrement_expression 
+        ;
+
+post_increment_decrement_expression: postfix_expression '++'
+        | postfix_expression '--'
         | postfix_expression
         ;
 
-postfix_expression: postfix_expression '[' expression ']'
-        |
+postfix_expression: identifier '[' expression ']'
+        | primary
         ;
 
 primary: identifier

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -103,6 +103,8 @@ pub enum ExprNode {
 
     PreIncrement(Box<ExprNode>),
     PreDecrement(Box<ExprNode>),
+    PostIncrement(Box<ExprNode>),
+    PostDecrement(Box<ExprNode>),
 
     // Pointer Operations
     Ref(String),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -101,6 +101,9 @@ pub enum ExprNode {
     Negate(Box<ExprNode>),
     Invert(Box<ExprNode>),
 
+    PreIncrement(Box<ExprNode>),
+    PreDecrement(Box<ExprNode>),
+
     // Pointer Operations
     Ref(String),
     Deref(Box<ExprNode>),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -390,7 +390,26 @@ fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprN
                 .map(Box::new)
                 .map(ExprNode::Invert)
         })
-        .or(postfix_expression)
+        .or(post_increment_decrement_expression)
+}
+
+fn post_increment_decrement_expression<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+    parcel::left(parcel::join(
+        whitespace_wrapped(postfix_expression()),
+        expect_str("++"),
+    ))
+    .map(Box::new)
+    .map(ExprNode::PostIncrement)
+    .or(|| {
+        parcel::left(parcel::join(
+            whitespace_wrapped(postfix_expression()),
+            whitespace_wrapped(expect_str("--")),
+        ))
+        .map(Box::new)
+        .map(ExprNode::PostDecrement)
+    })
+    .or(postfix_expression)
 }
 
 fn postfix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -355,6 +355,18 @@ fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprN
                 .and_then(|_| identifier())
                 .map(ExprNode::Ref)
         })
+        .or(|| {
+            whitespace_wrapped(expect_str("++"))
+                .and_then(|_| prefix_expression())
+                .map(Box::new)
+                .map(ExprNode::PreIncrement)
+        })
+        .or(|| {
+            whitespace_wrapped(expect_str("--"))
+                .and_then(|_| prefix_expression())
+                .map(Box::new)
+                .map(ExprNode::PreDecrement)
+        })
         // unary logical not
         .or(|| {
             whitespace_wrapped(expect_character('!'))

--- a/src/stage/ast/mod.rs
+++ b/src/stage/ast/mod.rs
@@ -174,6 +174,8 @@ pub enum TypedExprNode {
 
     PreIncrement(Type, Box<TypedExprNode>),
     PreDecrement(Type, Box<TypedExprNode>),
+    PostIncrement(Type, Box<TypedExprNode>),
+    PostDecrement(Type, Box<TypedExprNode>),
 
     // Pointer Operations
     Ref(Type, String),
@@ -204,8 +206,10 @@ impl Typed for TypedExprNode {
             | TypedExprNode::LogicalNot(ty, _)
             | TypedExprNode::Negate(ty, _)
             | TypedExprNode::Invert(ty, _)
-            | TypedExprNode::PreDecrement(ty, _)
             | TypedExprNode::PreIncrement(ty, _)
+            | TypedExprNode::PreDecrement(ty, _)
+            | TypedExprNode::PostIncrement(ty, _)
+            | TypedExprNode::PostDecrement(ty, _)
             | TypedExprNode::Ref(ty, _)
             | TypedExprNode::Deref(ty, _)
             | TypedExprNode::ScaleBy(ty, _)

--- a/src/stage/ast/mod.rs
+++ b/src/stage/ast/mod.rs
@@ -172,6 +172,9 @@ pub enum TypedExprNode {
     Negate(Type, Box<TypedExprNode>),
     Invert(Type, Box<TypedExprNode>),
 
+    PreIncrement(Type, Box<TypedExprNode>),
+    PreDecrement(Type, Box<TypedExprNode>),
+
     // Pointer Operations
     Ref(Type, String),
     Deref(Type, Box<TypedExprNode>),
@@ -201,6 +204,8 @@ impl Typed for TypedExprNode {
             | TypedExprNode::LogicalNot(ty, _)
             | TypedExprNode::Negate(ty, _)
             | TypedExprNode::Invert(ty, _)
+            | TypedExprNode::PreDecrement(ty, _)
+            | TypedExprNode::PreIncrement(ty, _)
             | TypedExprNode::Ref(ty, _)
             | TypedExprNode::Deref(ty, _)
             | TypedExprNode::ScaleBy(ty, _)

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -603,6 +603,36 @@ fn codegen_expr(
             }
             _ => unreachable!(),
         },
+        TypedExprNode::PostIncrement(_, expr) => match *expr {
+            TypedExprNode::Primary(ty, Primary::Identifier(_, identifier)) => {
+                let width = operand_width_of_type(ty.clone());
+                flattenable_instructions!(
+                    codegen_load_global(ty, ret_val, &identifier),
+                    vec![format!(
+                        "\tinc{}\t{}(%{})\n",
+                        operator_suffix(width),
+                        identifier,
+                        PointerRegister.fmt_with_operand_width(OperandWidth::QuadWord),
+                    )],
+                )
+            }
+            _ => unreachable!(),
+        },
+        TypedExprNode::PostDecrement(_, expr) => match *expr {
+            TypedExprNode::Primary(ty, Primary::Identifier(_, identifier)) => {
+                let width = operand_width_of_type(ty.clone());
+                flattenable_instructions!(
+                    codegen_load_global(ty, ret_val, &identifier),
+                    vec![format!(
+                        "\tdec{}\t{}(%{})\n",
+                        operator_suffix(width),
+                        identifier,
+                        PointerRegister.fmt_with_operand_width(OperandWidth::QuadWord),
+                    )],
+                )
+            }
+            _ => unreachable!(),
+        },
 
         TypedExprNode::Ref(_, identifier) => codegen_reference(ret_val, &identifier),
         TypedExprNode::Deref(ty, expr) => {

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -571,6 +571,39 @@ fn codegen_expr(
         TypedExprNode::Negate(_, expr) => codegen_negate(allocator, ret_val, *expr),
         TypedExprNode::Invert(_, expr) => codegen_invert(allocator, ret_val, *expr),
 
+        TypedExprNode::PreIncrement(_, expr) => match *expr {
+            TypedExprNode::Primary(ty, Primary::Identifier(_, identifier)) => {
+                let width = operand_width_of_type(ty.clone());
+
+                flattenable_instructions!(
+                    vec![format!(
+                        "\tinc{}\t{}(%{})\n",
+                        operator_suffix(width),
+                        identifier,
+                        PointerRegister.fmt_with_operand_width(OperandWidth::QuadWord),
+                    )],
+                    codegen_load_global(ty, ret_val, &identifier),
+                )
+            }
+            _ => unreachable!(),
+        },
+        TypedExprNode::PreDecrement(_, expr) => match *expr {
+            TypedExprNode::Primary(ty, Primary::Identifier(_, identifier)) => {
+                let width = operand_width_of_type(ty.clone());
+
+                flattenable_instructions!(
+                    vec![format!(
+                        "\tdec{}\t{}(%{})\n",
+                        operator_suffix(width),
+                        identifier,
+                        PointerRegister.fmt_with_operand_width(OperandWidth::QuadWord),
+                    )],
+                    codegen_load_global(ty, ret_val, &identifier),
+                )
+            }
+            _ => unreachable!(),
+        },
+
         TypedExprNode::Ref(_, identifier) => codegen_reference(ret_val, &identifier),
         TypedExprNode::Deref(ty, expr) => {
             flattenable_instructions!(

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -511,7 +511,7 @@ fn codegen_expr(
 
             flattenable_instructions!(
                 codegen_global_str(&identifier, &lit),
-                codegen_load_global(generate_type_specifier!(u64), ret_val, &identifier),
+                codegen_reference(ret_val, &identifier),
             )
         }
 

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -580,7 +580,7 @@ fn codegen_expr(
         ),
 
         TypedExprNode::Addition(Type::Pointer(ty), lhs, rhs) => {
-            codegen_addition(allocator, ret_val, *ty, lhs, rhs)
+            codegen_addition(allocator, ret_val, ty.pointer_to(), lhs, rhs)
         }
         TypedExprNode::Addition(ty, lhs, rhs) => codegen_addition(allocator, ret_val, ty, lhs, rhs),
         TypedExprNode::Subtraction(ty, lhs, rhs) => {
@@ -1346,7 +1346,7 @@ mod tests {
 \tmovq\t$1, %r13
 \tmovq\t$1, %r15
 \timulq\t%r13, %r15
-\taddb\t%r14b, %r15b
+\taddq\t%r14, %r15
 \tmovb\t(%r15), %r15b
 "
             .to_string()]),

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -660,7 +660,7 @@ impl TypeAnalysis {
             CompatibilityResult::WidenTo(ty) => Some((ty, lhs, rhs)),
             CompatibilityResult::Incompatible => None,
             CompatibilityResult::Scale(ty) => Some((
-                ty.clone(),
+                ty.pointer_to(),
                 lhs,
                 ast::TypedExprNode::ScaleBy(ty, Box::new(rhs)),
             )),

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -678,6 +678,10 @@ impl TypeAnalysis {
                 lvalue_expr @ TypedExprNode::Primary(_, ast::Primary::Identifier(_, _)) => {
                     Ok(lvalue_expr)
                 }
+
+                lvalue_expr if matches!(ty_expr.r#type(), ast::Type::Pointer(_)) => Ok(lvalue_expr),
+
+                // r-value expressions are not valid for ++/-- operators
                 rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
             })
             .map(|expr| match variant {

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -562,6 +562,23 @@ impl TypeAnalysis {
                 .map(|expr| (expr.r#type(), expr))
                 .map(|(expr_type, expr)| ast::TypedExprNode::Invert(expr_type, Box::new(expr))),
 
+            ExprNode::PreIncrement(expr) => match *expr {
+                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => {
+                    self.analyze_expression(lvalue_expr).map(|ident_expr| {
+                        ast::TypedExprNode::PreIncrement(ident_expr.r#type(), Box::new(ident_expr))
+                    })
+                }
+                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
+            },
+            ExprNode::PreDecrement(expr) => match *expr {
+                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => {
+                    self.analyze_expression(lvalue_expr).map(|ident_expr| {
+                        ast::TypedExprNode::PreDecrement(ident_expr.r#type(), Box::new(ident_expr))
+                    })
+                }
+                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
+            },
+
             ExprNode::Ref(identifier) => self
                 .scopes
                 .lookup(&identifier)

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -563,19 +563,27 @@ impl TypeAnalysis {
                 .map(|(expr_type, expr)| ast::TypedExprNode::Invert(expr_type, Box::new(expr))),
 
             ExprNode::PreIncrement(expr) => match *expr {
-                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => {
-                    self.analyze_expression(lvalue_expr).map(|ident_expr| {
-                        ast::TypedExprNode::PreIncrement(ident_expr.r#type(), Box::new(ident_expr))
-                    })
-                }
+                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
+                    .analyze_expression(lvalue_expr)
+                    .map(|expr| ast::TypedExprNode::PreIncrement(expr.r#type(), Box::new(expr))),
                 rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
             },
             ExprNode::PreDecrement(expr) => match *expr {
-                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => {
-                    self.analyze_expression(lvalue_expr).map(|ident_expr| {
-                        ast::TypedExprNode::PreDecrement(ident_expr.r#type(), Box::new(ident_expr))
-                    })
-                }
+                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
+                    .analyze_expression(lvalue_expr)
+                    .map(|expr| ast::TypedExprNode::PreDecrement(expr.r#type(), Box::new(expr))),
+                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
+            },
+            ExprNode::PostIncrement(expr) => match *expr {
+                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
+                    .analyze_expression(lvalue_expr)
+                    .map(|expr| ast::TypedExprNode::PostIncrement(expr.r#type(), Box::new(expr))),
+                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
+            },
+            ExprNode::PostDecrement(expr) => match *expr {
+                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
+                    .analyze_expression(lvalue_expr)
+                    .map(|expr| ast::TypedExprNode::PostDecrement(expr.r#type(), Box::new(expr))),
                 rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
             },
 

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -562,31 +562,18 @@ impl TypeAnalysis {
                 .map(|expr| (expr.r#type(), expr))
                 .map(|(expr_type, expr)| ast::TypedExprNode::Invert(expr_type, Box::new(expr))),
 
-            ExprNode::PreIncrement(expr) => match *expr {
-                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
-                    .analyze_expression(lvalue_expr)
-                    .map(|expr| ast::TypedExprNode::PreIncrement(expr.r#type(), Box::new(expr))),
-                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
-            },
-            ExprNode::PreDecrement(expr) => match *expr {
-                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
-                    .analyze_expression(lvalue_expr)
-                    .map(|expr| ast::TypedExprNode::PreDecrement(expr.r#type(), Box::new(expr))),
-                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
-            },
-            ExprNode::PostIncrement(expr) => match *expr {
-                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
-                    .analyze_expression(lvalue_expr)
-                    .map(|expr| ast::TypedExprNode::PostIncrement(expr.r#type(), Box::new(expr))),
-                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
-            },
-            ExprNode::PostDecrement(expr) => match *expr {
-                lvalue_expr @ ExprNode::Primary(Primary::Identifier(_)) => self
-                    .analyze_expression(lvalue_expr)
-                    .map(|expr| ast::TypedExprNode::PostDecrement(expr.r#type(), Box::new(expr))),
-                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
-            },
-
+            ExprNode::PreIncrement(expr) => {
+                self.analyze_inc_dec_expr(IncDecExpr::PreIncrement, *expr)
+            }
+            ExprNode::PreDecrement(expr) => {
+                self.analyze_inc_dec_expr(IncDecExpr::PreDecrement, *expr)
+            }
+            ExprNode::PostIncrement(expr) => {
+                self.analyze_inc_dec_expr(IncDecExpr::PostIncrement, *expr)
+            }
+            ExprNode::PostDecrement(expr) => {
+                self.analyze_inc_dec_expr(IncDecExpr::PostDecrement, *expr)
+            }
             ExprNode::Ref(identifier) => self
                 .scopes
                 .lookup(&identifier)
@@ -679,6 +666,43 @@ impl TypeAnalysis {
             )),
         }
     }
+
+    fn analyze_inc_dec_expr(
+        &self,
+        variant: IncDecExpr,
+        expr: crate::parser::ast::ExprNode,
+    ) -> Result<ast::TypedExprNode, String> {
+        use ast::TypedExprNode;
+        self.analyze_expression(expr)
+            .and_then(|ty_expr| match ty_expr {
+                lvalue_expr @ TypedExprNode::Primary(_, ast::Primary::Identifier(_, _)) => {
+                    Ok(lvalue_expr)
+                }
+                rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
+            })
+            .map(|expr| match variant {
+                IncDecExpr::PreIncrement => {
+                    TypedExprNode::PreIncrement(expr.r#type(), Box::new(expr))
+                }
+                IncDecExpr::PreDecrement => {
+                    TypedExprNode::PreDecrement(expr.r#type(), Box::new(expr))
+                }
+                IncDecExpr::PostIncrement => {
+                    TypedExprNode::PostIncrement(expr.r#type(), Box::new(expr))
+                }
+                IncDecExpr::PostDecrement => {
+                    TypedExprNode::PostDecrement(expr.r#type(), Box::new(expr))
+                }
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IncDecExpr {
+    PreIncrement,
+    PreDecrement,
+    PostIncrement,
+    PostDecrement,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Introduction
This PR starts the work of implementing the pre and post incrementer operators by defining them for identifiers only.

# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
