### PR TITLE
arrays should funtion separately from pointers on codegen

### DIFF
--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -618,24 +618,12 @@ impl TypeAnalysis {
                     .lookup(&identifier)
                     // validate that the reference is a pointer type
                     .and_then(|reference| {
-                        if reference.r#type.value_at().is_some() {
-                            Some(reference)
-                        } else {
-                            None
-                        }
-                    })
-                    .map(|dm| {
-                        let scale_by_ty = dm.r#type.value_at().unwrap();
-                        /*if dm.is_array() {
-                            // safe to unwrap due to above assertion.
-                            dm.r#type.value_at().unwrap()
-                        } else {
-                            dm.r#type.clone()
-                        };*/
-                        (
-                            dm,
-                            ast::TypedExprNode::ScaleBy(scale_by_ty, Box::new(index_expr)),
-                        )
+                        reference.r#type.value_at().map(|value_of_ref| {
+                            (
+                                reference,
+                                ast::TypedExprNode::ScaleBy(value_of_ref, Box::new(index_expr)),
+                            )
+                        })
                     })
                     .map(|(dm, scale)| {
                         let ref_ty = dm.r#type.clone();

--- a/src/stage/type_check/scopes.rs
+++ b/src/stage/type_check/scopes.rs
@@ -14,8 +14,16 @@ impl DeclarationMetadata {
         Self { r#type: ty, size }
     }
 
+    /// Returns a boolean signifying a type is a fixed size array.
     pub fn is_array(&self) -> bool {
-        self.size.is_some()
+        (matches!(self.r#type, Type::Pointer(_)) && self.size.is_some())
+    }
+
+    /// Returns a boolean signifying a type is a direct refence type.
+    /// i.e. not a pointer.
+    #[allow(unused)]
+    pub fn is_direct_reference(&self) -> bool {
+        self.is_array() || !matches!(self.r#type, Type::Pointer(_))
     }
 }
 

--- a/src/stage/type_check/scopes.rs
+++ b/src/stage/type_check/scopes.rs
@@ -1,5 +1,7 @@
 use crate::stage::ast::Type;
 
+/// DeclarationMetadata contains information about a given declared variable.
+/// This information currenntly includes defined size and type.
 #[derive(Debug, Clone)]
 pub struct DeclarationMetadata {
     pub r#type: Type,

--- a/src/stage/type_check/scopes.rs
+++ b/src/stage/type_check/scopes.rs
@@ -3,11 +3,19 @@ use crate::stage::ast::Type;
 #[derive(Debug, Clone)]
 pub struct DeclarationMetadata {
     pub r#type: Type,
+    // if Some, implies that this is a fixed size array of a known size.
+    // Otherwise it is a singular type be it a known value or pointer to a
+    // value.
+    pub size: Option<usize>,
 }
 
 impl DeclarationMetadata {
-    pub fn new(ty: Type) -> Self {
-        Self { r#type: ty }
+    pub fn new(ty: Type, size: Option<usize>) -> Self {
+        Self { r#type: ty, size }
+    }
+
+    pub fn is_array(&self) -> bool {
+        self.size.is_some()
     }
 }
 
@@ -40,7 +48,14 @@ impl ScopeStack {
     pub fn define_mut(&mut self, id: &str, ty: Type) {
         self.scopes
             .last_mut()
-            .map(|scope| scope.insert(id.to_string(), DeclarationMetadata::new(ty)));
+            .map(|scope| scope.insert(id.to_string(), DeclarationMetadata::new(ty, None)));
+    }
+
+    /// Defines a new variable in place.
+    pub fn define_with_size_mut(&mut self, id: &str, ty: Type, size: usize) {
+        self.scopes
+            .last_mut()
+            .map(|scope| scope.insert(id.to_string(), DeclarationMetadata::new(ty, Some(size))));
     }
 
     /// looks up variable in place.


### PR DESCRIPTION
# Introduction
Small PR to update the behavior of reference types to use mov for direct referenced types (arrays) and lea for reference types.
# Linked Issues
resolves #109 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
