### PR TITLE
Implement incrementer operations on pointer types

### DIFF
--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -373,6 +373,43 @@ fn codegen_inc_or_dec_expression_from_identifier(
     }
 }
 
+fn codegen_inc_or_dec_expression_from_pointer(
+    ty: Type,
+    allocator: &mut GPRegisterAllocator,
+    ret_val: &mut GeneralPurposeRegister,
+    expr_op: IncDecExpression,
+) -> Vec<String> {
+    let width = operand_width_of_type(ty.clone());
+
+    allocator.allocate_then(|_, ptr_reg| {
+        let op = match expr_op {
+            IncDecExpression::PreIncrement | IncDecExpression::PostIncrement => format!(
+                "\tinc{}\t(%{})\n",
+                operator_suffix(width),
+                ptr_reg.fmt_with_operand_width(OperandWidth::QuadWord),
+            ),
+            IncDecExpression::PreDecrement | IncDecExpression::PostDecrement => format!(
+                "\tdec{}\t(%{})\n",
+                operator_suffix(width),
+                ptr_reg.fmt_with_operand_width(OperandWidth::QuadWord),
+            ),
+        };
+
+        flattenable_instructions!(
+            vec![
+                format!(
+                    "\tmov{}\t%{}, %{}\n",
+                    operator_suffix(OperandWidth::QuadWord),
+                    ret_val.fmt_with_operand_width(OperandWidth::QuadWord),
+                    ptr_reg.fmt_with_operand_width(OperandWidth::QuadWord)
+                ),
+                op,
+            ],
+            codegen_deref(ret_val, ty, 0),
+        )
+    })
+}
+
 fn codegen_load_global(
     ty: Type,
     ret: &mut GeneralPurposeRegister,
@@ -538,12 +575,12 @@ fn codegen_expr(
                 codegen_store_global(ty, ret_val, &identifier),
             )
         }
-        TypedExprNode::DerefAssignment(_, lhs, rhs) => {
+        TypedExprNode::DerefAssignment(ty, lhs, rhs) => {
             allocator.allocate_then(|allocator, rhs_ret_val| {
                 flattenable_instructions!(
                     codegen_expr(allocator, rhs_ret_val, *rhs),
                     codegen_expr(allocator, ret_val, *lhs),
-                    codegen_store_deref(ret_val, rhs_ret_val),
+                    codegen_store_deref(ty, ret_val, rhs_ret_val),
                 )
             })
         }
@@ -632,6 +669,18 @@ fn codegen_expr(
                     ret_val,
                     &identifier,
                     IncDecExpression::PreIncrement,
+                )
+            }
+
+            TypedExprNode::Deref(ty, expr) => {
+                flattenable_instructions!(
+                    codegen_expr(allocator, ret_val, *expr),
+                    codegen_inc_or_dec_expression_from_pointer(
+                        ty,
+                        allocator,
+                        ret_val,
+                        IncDecExpression::PreIncrement,
+                    ),
                 )
             }
             _ => unreachable!(),
@@ -783,14 +832,16 @@ fn codegen_reference(ret: &mut GeneralPurposeRegister, identifier: &str) -> Vec<
 }
 
 fn codegen_store_deref(
+    ty: Type,
     dest: &mut GeneralPurposeRegister,
     src: &mut GeneralPurposeRegister,
 ) -> Vec<String> {
-    const WIDTH: OperandWidth = OperandWidth::QuadWord;
+    let width = operand_width_of_type(ty);
+
     vec![format!(
         "\tmov{}\t%{}, (%{})\n",
-        operator_suffix(WIDTH),
-        src.fmt_with_operand_width(WIDTH),
+        operator_suffix(width),
+        src.fmt_with_operand_width(width),
         dest.fmt_with_operand_width(OperandWidth::QuadWord)
     )]
 }

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -685,6 +685,8 @@ impl TypeAnalysis {
                     Ok(lvalue_expr)
                 }
 
+                lvalue_expr @ TypedExprNode::Deref(_, _) => Ok(lvalue_expr),
+
                 lvalue_expr if matches!(ty_expr.r#type(), ast::Type::Pointer(_)) => Ok(lvalue_expr),
 
                 // r-value expressions are not valid for ++/-- operators

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -687,8 +687,6 @@ impl TypeAnalysis {
 
                 lvalue_expr @ TypedExprNode::Deref(_, _) => Ok(lvalue_expr),
 
-                lvalue_expr if matches!(ty_expr.r#type(), ast::Type::Pointer(_)) => Ok(lvalue_expr),
-
                 // r-value expressions are not valid for ++/-- operators
                 rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),
             })

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -686,6 +686,17 @@ impl TypeAnalysis {
                 }
 
                 lvalue_expr @ TypedExprNode::Deref(_, _) => Ok(lvalue_expr),
+                TypedExprNode::Grouping(ty, inner_expr) => {
+                    let expr = *inner_expr;
+                    if let TypedExprNode::Deref(ty, expr) = expr {
+                        Ok(TypedExprNode::Deref(ty, expr))
+                    } else {
+                        Err(format!(
+                            "type {:?} is not an lvalue",
+                            TypedExprNode::Grouping(ty, Box::new(expr))
+                        ))
+                    }
+                }
 
                 // r-value expressions are not valid for ++/-- operators
                 rvalue_expr => Err(format!("type {:?} is not an lvalue", rvalue_expr)),


### PR DESCRIPTION
# Introduction
This PR completes the work of implementing incrementer `++` and `--` operators on pointer and array types.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
