### PR TITLE
Implement bitwise operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,22 @@ expression: assignment
         ;
 
 assignment:   identifier '=' assignment
-        | binary_logical
+        | logical
         ;
 
-binary_logical: equality ( ( '||' | '&&' ) equality )*
+logical: bitwise ( ( '||' | '&&' ) bitwise )*
+        ;
+
+bitwise: equality ( ( '|' | '^' | '&' ) equality )*
         ;
 
 equality: relational ( ( '==' | '!=' ) relational )*
         ;
 
-relational: addition ( ( '<' | '<=' | '>' | '>=' ) addition )*
+relational: bitwise_shift ( ( '<' | '<=' | '>' | '>=' ) bitwise_shift )*
+        ;
+
+bitwise_shift: addition ( ( '<<' | '>>' ) addition )*
         ;
 
 addition: multiplication ( ( '-' | '+' ) multiplication )* 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -157,12 +157,33 @@ macro_rules! binary_logical_expr {
     };
 }
 
+macro_rules! bitwise_expr {
+    ($lhs:expr, "|", $rhs:expr) => {
+        $crate::parser::ast::ExprNode::BitOr(Box::new($lhs), Box::new($rhs))
+    };
+    ($lhs:expr, "^", $rhs:expr) => {
+        $crate::parser::ast::ExprNode::BitXor(Box::new($lhs), Box::new($rhs))
+    };
+    ($lhs:expr, "&", $rhs:expr) => {
+        $crate::parser::ast::ExprNode::BitAnd(Box::new($lhs), Box::new($rhs))
+    };
+}
+
 macro_rules! equality_expr {
     ($lhs:expr, "==", $rhs:expr) => {
         $crate::parser::ast::ExprNode::Equal(Box::new($lhs), Box::new($rhs))
     };
     ($lhs:expr, "!=", $rhs:expr) => {
         $crate::parser::ast::ExprNode::NotEqual(Box::new($lhs), Box::new($rhs))
+    };
+}
+
+macro_rules! bitwise_shift_expr {
+    ($lhs:expr, "<<", $rhs:expr) => {
+        $crate::parser::ast::ExprNode::BitShiftLeft(Box::new($lhs), Box::new($rhs))
+    };
+    ($lhs:expr, ">>", $rhs:expr) => {
+        $crate::parser::ast::ExprNode::BitShiftRight(Box::new($lhs), Box::new($rhs))
     };
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -82,8 +82,13 @@ pub enum ExprNode {
     Assignment(Box<ExprNode>, Box<ExprNode>),
 
     // Binary Logical
-    LogAnd(Box<ExprNode>, Box<ExprNode>),
     LogOr(Box<ExprNode>, Box<ExprNode>),
+    LogAnd(Box<ExprNode>, Box<ExprNode>),
+
+    // Bitwise
+    BitOr(Box<ExprNode>, Box<ExprNode>),
+    BitXor(Box<ExprNode>, Box<ExprNode>),
+    BitAnd(Box<ExprNode>, Box<ExprNode>),
 
     // Comparative
     Equal(Box<ExprNode>, Box<ExprNode>),
@@ -92,6 +97,10 @@ pub enum ExprNode {
     GreaterThan(Box<ExprNode>, Box<ExprNode>),
     LessEqual(Box<ExprNode>, Box<ExprNode>),
     GreaterEqual(Box<ExprNode>, Box<ExprNode>),
+
+    // Bitwise shift
+    BitShiftLeft(Box<ExprNode>, Box<ExprNode>),
+    BitShiftRight(Box<ExprNode>, Box<ExprNode>),
 
     // Arithmetic
     Addition(Box<ExprNode>, Box<ExprNode>),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -194,27 +194,27 @@ fn expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
 
 fn assignment<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
     parcel::join(
-        whitespace_wrapped(binary_logical()),
+        whitespace_wrapped(logical()),
         whitespace_wrapped(expect_character('=')).and_then(|_| whitespace_wrapped(assignment())),
     )
     .map(|(lhs, rhs)| assignment_expr!(lhs, '=', rhs))
-    .or(binary_logical)
+    .or(logical)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum BinaryLogicalExprOp {
+enum LogicalExprOp {
     LogAnd,
     LogOr,
 }
 
-fn binary_logical<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn logical<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
     parcel::join(
         equality(),
         parcel::zero_or_more(parcel::join(
             whitespace_wrapped(
                 expect_str("||")
-                    .map(|_| BinaryLogicalExprOp::LogOr)
-                    .or(|| expect_str("&&").map(|_| BinaryLogicalExprOp::LogAnd)),
+                    .map(|_| LogicalExprOp::LogOr)
+                    .or(|| expect_str("&&").map(|_| LogicalExprOp::LogAnd)),
             ),
             whitespace_wrapped(equality()),
         ))
@@ -225,8 +225,8 @@ fn binary_logical<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode
             .into_iter()
             .zip(operands.into_iter())
             .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                BinaryLogicalExprOp::LogOr => binary_logical_expr!(lhs, "||", rhs),
-                BinaryLogicalExprOp::LogAnd => binary_logical_expr!(lhs, "&&", rhs),
+                LogicalExprOp::LogOr => binary_logical_expr!(lhs, "||", rhs),
+                LogicalExprOp::LogAnd => binary_logical_expr!(lhs, "&&", rhs),
             })
     })
 }

--- a/src/stage/ast/mod.rs
+++ b/src/stage/ast/mod.rs
@@ -153,8 +153,13 @@ pub enum TypedExprNode {
     DerefAssignment(Type, Box<TypedExprNode>, Box<TypedExprNode>),
 
     // Binary Logical
-    LogAnd(Type, Box<TypedExprNode>, Box<TypedExprNode>),
     LogOr(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+    LogAnd(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+
+    // Bitwise
+    BitOr(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+    BitXor(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+    BitAnd(Type, Box<TypedExprNode>, Box<TypedExprNode>),
 
     // Comparative
     Equal(Type, Box<TypedExprNode>, Box<TypedExprNode>),
@@ -163,6 +168,10 @@ pub enum TypedExprNode {
     GreaterThan(Type, Box<TypedExprNode>, Box<TypedExprNode>),
     LessEqual(Type, Box<TypedExprNode>, Box<TypedExprNode>),
     GreaterEqual(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+
+    // Bitwise shift
+    BitShiftLeft(Type, Box<TypedExprNode>, Box<TypedExprNode>),
+    BitShiftRight(Type, Box<TypedExprNode>, Box<TypedExprNode>),
 
     // Arithmetic
     Addition(Type, Box<TypedExprNode>, Box<TypedExprNode>),
@@ -196,12 +205,17 @@ impl Typed for TypedExprNode {
             | TypedExprNode::FunctionCall(ty, _, _)
             | TypedExprNode::IdentifierAssignment(ty, _, _)
             | TypedExprNode::DerefAssignment(ty, _, _)
+            | TypedExprNode::BitOr(ty, _, _)
+            | TypedExprNode::BitXor(ty, _, _)
+            | TypedExprNode::BitAnd(ty, _, _)
             | TypedExprNode::Equal(ty, _, _)
             | TypedExprNode::NotEqual(ty, _, _)
             | TypedExprNode::LessThan(ty, _, _)
             | TypedExprNode::GreaterThan(ty, _, _)
             | TypedExprNode::LessEqual(ty, _, _)
             | TypedExprNode::GreaterEqual(ty, _, _)
+            | TypedExprNode::BitShiftLeft(ty, _, _)
+            | TypedExprNode::BitShiftRight(ty, _, _)
             | TypedExprNode::Addition(ty, _, _)
             | TypedExprNode::Subtraction(ty, _, _)
             | TypedExprNode::Division(ty, _, _)

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -610,6 +610,10 @@ fn codegen_expr(
         TypedExprNode::LogOr(_, lhs, rhs) => codegen_or(allocator, ret_val, *lhs, *rhs),
         TypedExprNode::LogAnd(_, lhs, rhs) => codegen_and(allocator, ret_val, *lhs, *rhs),
 
+        TypedExprNode::BitOr(_, _, _) => todo!(),
+        TypedExprNode::BitXor(_, _, _) => todo!(),
+        TypedExprNode::BitAnd(_, _, _) => todo!(),
+
         TypedExprNode::Equal(ty, lhs, rhs) => {
             codegen_compare_and_set(allocator, ret_val, ComparisonOperation::Equal, ty, lhs, rhs)
         }
@@ -653,6 +657,9 @@ fn codegen_expr(
             lhs,
             rhs,
         ),
+
+        TypedExprNode::BitShiftLeft(_, _, _) => todo!(),
+        TypedExprNode::BitShiftRight(_, _, _) => todo!(),
 
         TypedExprNode::Addition(Type::Pointer(ty), lhs, rhs) => {
             codegen_addition(allocator, ret_val, ty.pointer_to(), lhs, rhs)

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -552,6 +552,14 @@ impl TypeAnalysis {
 
             ExprNode::BitShiftLeft(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
+                .and_then(|(expr_type, lhs, rhs)| {
+                    match generate_type_specifier!(u8).type_compatible(&rhs.r#type(), true) {
+                        CompatibilityResult::Scale(_) | CompatibilityResult::Incompatible => None,
+                        CompatibilityResult::Equivalent | CompatibilityResult::WidenTo(_) => {
+                            Some((expr_type, lhs, rhs))
+                        }
+                    }
+                })
                 .map(|(expr_type, lhs, rhs)| {
                     ast::TypedExprNode::BitShiftLeft(expr_type, Box::new(lhs), Box::new(rhs))
                 })
@@ -559,6 +567,14 @@ impl TypeAnalysis {
 
             ExprNode::BitShiftRight(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
+                .and_then(|(expr_type, lhs, rhs)| {
+                    match generate_type_specifier!(u8).type_compatible(&rhs.r#type(), true) {
+                        CompatibilityResult::Scale(_) | CompatibilityResult::Incompatible => None,
+                        CompatibilityResult::Equivalent | CompatibilityResult::WidenTo(_) => {
+                            Some((expr_type, lhs, rhs))
+                        }
+                    }
+                })
                 .map(|(expr_type, lhs, rhs)| {
                     ast::TypedExprNode::BitShiftRight(expr_type, Box::new(lhs), Box::new(rhs))
                 })

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -490,6 +490,11 @@ impl TypeAnalysis {
                     ast::TypedExprNode::LogAnd(ty, Box::new(lhs), Box::new(rhs))
                 })
                 .ok_or_else(|| "incompatible types for logical and comparison".to_string()),
+
+            ExprNode::BitOr(_, _) => todo!(),
+            ExprNode::BitXor(_, _) => todo!(),
+            ExprNode::BitAnd(_, _) => todo!(),
+
             ExprNode::Equal(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
                 .map(|(expr_type, lhs, rhs)| {
@@ -526,6 +531,10 @@ impl TypeAnalysis {
                     ast::TypedExprNode::GreaterThan(expr_type, Box::new(lhs), Box::new(rhs))
                 })
                 .ok_or_else(|| "invalid type".to_string()),
+
+            ExprNode::BitShiftLeft(_, _) => todo!(),
+            ExprNode::BitShiftRight(_, _) => todo!(),
+
             ExprNode::Addition(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
                 .map(|(expr_type, lhs, rhs)| {

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -491,9 +491,27 @@ impl TypeAnalysis {
                 })
                 .ok_or_else(|| "incompatible types for logical and comparison".to_string()),
 
-            ExprNode::BitOr(_, _) => todo!(),
-            ExprNode::BitXor(_, _) => todo!(),
-            ExprNode::BitAnd(_, _) => todo!(),
+            ExprNode::BitOr(lhs, rhs) => self
+                .analyze_binary_expr(*lhs, *rhs)
+                .map(|(_, lhs, rhs)| {
+                    let ty = ast::Type::Integer(ast::Signed::Unsigned, ast::IntegerWidth::One);
+                    ast::TypedExprNode::BitOr(ty, Box::new(lhs), Box::new(rhs))
+                })
+                .ok_or_else(|| "incompatible types for bitwise or operation".to_string()),
+            ExprNode::BitXor(lhs, rhs) => self
+                .analyze_binary_expr(*lhs, *rhs)
+                .map(|(_, lhs, rhs)| {
+                    let ty = ast::Type::Integer(ast::Signed::Unsigned, ast::IntegerWidth::One);
+                    ast::TypedExprNode::BitXor(ty, Box::new(lhs), Box::new(rhs))
+                })
+                .ok_or_else(|| "incompatible types for bitwise xor operation".to_string()),
+            ExprNode::BitAnd(lhs, rhs) => self
+                .analyze_binary_expr(*lhs, *rhs)
+                .map(|(_, lhs, rhs)| {
+                    let ty = ast::Type::Integer(ast::Signed::Unsigned, ast::IntegerWidth::One);
+                    ast::TypedExprNode::BitAnd(ty, Box::new(lhs), Box::new(rhs))
+                })
+                .ok_or_else(|| "incompatible types for bitwise and operation".to_string()),
 
             ExprNode::Equal(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
@@ -532,8 +550,19 @@ impl TypeAnalysis {
                 })
                 .ok_or_else(|| "invalid type".to_string()),
 
-            ExprNode::BitShiftLeft(_, _) => todo!(),
-            ExprNode::BitShiftRight(_, _) => todo!(),
+            ExprNode::BitShiftLeft(lhs, rhs) => self
+                .analyze_binary_expr(*lhs, *rhs)
+                .map(|(expr_type, lhs, rhs)| {
+                    ast::TypedExprNode::BitShiftLeft(expr_type, Box::new(lhs), Box::new(rhs))
+                })
+                .ok_or_else(|| "incompatible operands to left shift operation".to_string()),
+
+            ExprNode::BitShiftRight(lhs, rhs) => self
+                .analyze_binary_expr(*lhs, *rhs)
+                .map(|(expr_type, lhs, rhs)| {
+                    ast::TypedExprNode::BitShiftRight(expr_type, Box::new(lhs), Box::new(rhs))
+                })
+                .ok_or_else(|| "incompatible operands to right shift operation".to_string()),
 
             ExprNode::Addition(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)


### PR DESCRIPTION
# Introduction
This PR introduces bitwise `|`, `^`, `&`, `<<` and `>>` operators.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
