### PR TITLE
Add mechanism to parser to guarantee identifier is not keyword

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,5 +1,13 @@
 use crate::stage::ast::{self, Declaration, IntegerWidth, Signed};
 
+/// Represents a list of reserved keywords in C.
+pub(crate) const RESERVED_KEYWORDS: [&str; 32] = [
+    "auto", "void", "char", "short", "int", "long", "float", "double", "sizeof", "struct", "enum",
+    "union", "typedef", "register", "extern", "const", "unsigned", "static", "signed", "volatile",
+    "switch", "case", "default", "if", "else", "do", "while", "for", "continue", "break", "goto",
+    "return",
+];
+
 #[derive(Debug)]
 pub struct CompilationUnit {
     pub defs: Vec<GlobalDecls>,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,11 +1,11 @@
 use crate::stage::ast::{self, Declaration, IntegerWidth, Signed};
 
 #[derive(Debug)]
-pub struct Program {
+pub struct CompilationUnit {
     pub defs: Vec<GlobalDecls>,
 }
 
-impl Program {
+impl CompilationUnit {
     pub fn new(defs: Vec<GlobalDecls>) -> Self {
         Self { defs }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,7 +17,7 @@ pub enum ParseErr {
 
 /// parse expects a character slice as input and attempts to parse a valid
 /// expression, returning a parse error if it is invalid.
-pub fn parse(input: &[(usize, char)]) -> Result<Program, ParseErr> {
+pub fn parse(input: &[(usize, char)]) -> Result<CompilationUnit, ParseErr> {
     parcel::one_or_more(function_declaration().map(ast::GlobalDecls::Func).or(|| {
         semicolon_terminated_statement(declaration()).map(|stmt| {
             // safe to unpack due to declaration guarantee.
@@ -38,7 +38,7 @@ pub fn parse(input: &[(usize, char)]) -> Result<Program, ParseErr> {
         } => Ok(inner),
         MatchStatus::NoMatch(_) => Err(ParseErr::Unspecified("not a valid expression".to_string())),
     })
-    .map(Program::new)
+    .map(CompilationUnit::new)
 }
 
 fn function_declaration<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], FunctionDeclaration> {

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -164,8 +164,13 @@ impl TypeAnalysis {
     }
 }
 
-impl CompilationStage<crate::parser::ast::Program, ast::TypedProgram, String> for TypeAnalysis {
-    fn apply(&mut self, input: crate::parser::ast::Program) -> Result<ast::TypedProgram, String> {
+impl CompilationStage<crate::parser::ast::CompilationUnit, ast::TypedProgram, String>
+    for TypeAnalysis
+{
+    fn apply(
+        &mut self,
+        input: crate::parser::ast::CompilationUnit,
+    ) -> Result<ast::TypedProgram, String> {
         input
             .defs
             .into_iter()


### PR DESCRIPTION
# Introduction
This PR adds a Reserved Keyword list to the parser. Additionally this adds a predicate to identifier parsing to validate that an identifier is not a valid keyword.
# Linked Issues
resolves #75 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
