### PR TITLE
Smaller parser keyword test

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1057,12 +1057,11 @@ mod tests {
         let input: Vec<(usize, char)> = "{ return auto; }".chars().enumerate().collect();
         let res = crate::parser::compound_statements()
             .parse(&input)
-            .map_err(|_| ())
+            .ok()
             .and_then(|ms| match ms {
-                parcel::MatchStatus::Match { .. } => Err(()),
-                parcel::MatchStatus::NoMatch(_) => Ok(()),
-            })
-            .ok();
+                parcel::MatchStatus::Match { .. } => None,
+                parcel::MatchStatus::NoMatch(_) => Some(()),
+            });
 
         assert!(res.is_some());
     }


### PR DESCRIPTION
# Introduction
Small fix to simplify the test from #118 to convert to an `Option` earlier in the parse.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
