### PR TITLE
Add character literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,16 @@ postfix_expression: identifier '[' expression ']'
 primary: identifier
         | string_literal
         | digit
+        | char
         | grouping 
         ;
 
 char:   ascii_alphabetic
         ;
+
+char_literal: '\'' ascii_alphabetic '\''
+        ;
+
 
 grouping: '(' expression ')'
         ;


### PR DESCRIPTION
# Introduction
This PR introduces ascii character literals in the form of the following.

```c
int main() {
	int x;
	x = 'a';

	return x;
}
```

# Linked Issues
resolves #98 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
