### PR TITLE
Remove register move requirement for local slot

### DIFF
--- a/src/stage/codegen/machine/arch/x86_64/allocator/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/allocator/mod.rs
@@ -42,7 +42,8 @@ where
                 format!(
                     "{}({})",
                     offset,
-                    register::BasePointerRegister.fmt_with_operand_width(width)
+                    register::BasePointerRegister
+                        .fmt_with_operand_width(register::OperandWidth::QuadWord)
                 )
             }
         }

--- a/src/stage/codegen/machine/arch/x86_64/allocator/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/allocator/mod.rs
@@ -3,6 +3,51 @@ use std::ops::Range;
 pub use crate::stage::type_check::ast::ByteSized;
 
 pub mod register;
+use register::WidthFormatted;
+
+/// Provides an enumerable type for a location that can be either a
+/// register or offset.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RegisterOrOffset<GP>
+where
+    GP: WidthFormatted,
+{
+    Register(GP),
+    Offset(isize),
+}
+
+impl<GP> WidthFormatted for RegisterOrOffset<GP>
+where
+    GP: WidthFormatted,
+    <GP as register::WidthFormatted>::Output: std::string::ToString,
+{
+    type Output = String;
+
+    fn fmt_with_operand_width(&self, width: register::OperandWidth) -> Self::Output {
+        (&self).fmt_with_operand_width(width)
+    }
+}
+
+impl<GP> WidthFormatted for &RegisterOrOffset<GP>
+where
+    GP: WidthFormatted,
+    <GP as register::WidthFormatted>::Output: std::string::ToString,
+{
+    type Output = String;
+
+    fn fmt_with_operand_width(&self, width: register::OperandWidth) -> Self::Output {
+        match self {
+            RegisterOrOffset::Register(reg) => reg.fmt_with_operand_width(width).to_string(),
+            RegisterOrOffset::Offset(offset) => {
+                format!(
+                    "{}({})",
+                    offset,
+                    register::BasePointerRegister.fmt_with_operand_width(width)
+                )
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct SysVAllocator {
@@ -20,16 +65,31 @@ impl SysVAllocator {
 }
 
 impl SysVAllocator {
-    pub fn allocate_gp_register_then<F, R>(&mut self, f: F) -> R
+    /// Handles the allocation of, and corresponding free of a general-purpose
+    /// register, which is passed to a given closure. The return of the closure
+    /// is returned after freeing the register.
+    pub fn allocate_general_purpose_register_then<F, R>(&mut self, f: F) -> R
     where
-        F: FnOnce(&mut Self, &register::GeneralPurposeRegister) -> R,
+        F: FnOnce(&mut Self, &mut RegisterOrOffset<&register::GeneralPurposeRegister>) -> R,
     {
         self.general_purpose_reg_allocator
             .allocate()
             .map(|guard| {
-                let ret_val = f(self, guard.borrow_inner());
+                let ret_val = f(self, &mut RegisterOrOffset::Register(guard.borrow_inner()));
                 ret_val
             })
+            .expect("unable to allocate register")
+    }
+
+    /// Allocates a register, passing the corresponding register ticket to a closure.
+    #[allow(unused)]
+    pub fn allocate_general_purpose_register_with_guard_then<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut Self, RegisterOrOffset<register::RegisterAllocationGuard>) -> R,
+    {
+        self.general_purpose_reg_allocator
+            .allocate()
+            .map(|guard| f(self, RegisterOrOffset::Register(guard)))
             .expect("unable to allocate register")
     }
 

--- a/src/stage/codegen/machine/arch/x86_64/allocator/register.rs
+++ b/src/stage/codegen/machine/arch/x86_64/allocator/register.rs
@@ -25,9 +25,9 @@ impl WidthFormatted for PointerRegister {
 
     fn fmt_with_operand_width(&self, width: OperandWidth) -> Self::Output {
         match width {
-            OperandWidth::QuadWord => "rip",
-            OperandWidth::DoubleWord => "eip",
-            OperandWidth::Word => "ip",
+            OperandWidth::QuadWord => "%rip",
+            OperandWidth::DoubleWord => "%eip",
+            OperandWidth::Word => "%ip",
             OperandWidth::Byte => panic!("instruction pointer cannot be byte formatted"),
         }
     }
@@ -41,14 +41,15 @@ impl WidthFormatted for BasePointerRegister {
 
     fn fmt_with_operand_width(&self, width: OperandWidth) -> Self::Output {
         match width {
-            OperandWidth::QuadWord => "rbp",
-            OperandWidth::DoubleWord => "ebp",
-            OperandWidth::Word => "bp",
+            OperandWidth::QuadWord => "%rbp",
+            OperandWidth::DoubleWord => "%ebp",
+            OperandWidth::Word => "%bp",
             OperandWidth::Byte => panic!("base pointer pointer cannot be byte formatted"),
         }
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IntegerRegister {
     A,
@@ -74,71 +75,71 @@ impl WidthFormatted for IntegerRegister {
 
     fn fmt_with_operand_width(&self, width: OperandWidth) -> Self::Output {
         match (self, width) {
-            (IntegerRegister::A, OperandWidth::QuadWord) => "rax",
-            (IntegerRegister::A, OperandWidth::DoubleWord) => "eax",
-            (IntegerRegister::A, OperandWidth::Word) => "ax",
-            (IntegerRegister::A, OperandWidth::Byte) => "al",
-            (IntegerRegister::B, OperandWidth::QuadWord) => "rbx",
-            (IntegerRegister::B, OperandWidth::DoubleWord) => "ebx",
-            (IntegerRegister::B, OperandWidth::Word) => "bx",
-            (IntegerRegister::B, OperandWidth::Byte) => "bl",
-            (IntegerRegister::C, OperandWidth::QuadWord) => "rcx",
-            (IntegerRegister::C, OperandWidth::DoubleWord) => "ecx",
-            (IntegerRegister::C, OperandWidth::Word) => "cx",
-            (IntegerRegister::C, OperandWidth::Byte) => "cl",
-            (IntegerRegister::D, OperandWidth::QuadWord) => "rdx",
-            (IntegerRegister::D, OperandWidth::DoubleWord) => "edx",
-            (IntegerRegister::D, OperandWidth::Word) => "dx",
-            (IntegerRegister::D, OperandWidth::Byte) => "dl",
+            (IntegerRegister::A, OperandWidth::QuadWord) => "%rax",
+            (IntegerRegister::A, OperandWidth::DoubleWord) => "%eax",
+            (IntegerRegister::A, OperandWidth::Word) => "%ax",
+            (IntegerRegister::A, OperandWidth::Byte) => "%al",
+            (IntegerRegister::B, OperandWidth::QuadWord) => "%rbx",
+            (IntegerRegister::B, OperandWidth::DoubleWord) => "%ebx",
+            (IntegerRegister::B, OperandWidth::Word) => "%bx",
+            (IntegerRegister::B, OperandWidth::Byte) => "%bl",
+            (IntegerRegister::C, OperandWidth::QuadWord) => "%rcx",
+            (IntegerRegister::C, OperandWidth::DoubleWord) => "%ecx",
+            (IntegerRegister::C, OperandWidth::Word) => "%cx",
+            (IntegerRegister::C, OperandWidth::Byte) => "%cl",
+            (IntegerRegister::D, OperandWidth::QuadWord) => "%rdx",
+            (IntegerRegister::D, OperandWidth::DoubleWord) => "%edx",
+            (IntegerRegister::D, OperandWidth::Word) => "%dx",
+            (IntegerRegister::D, OperandWidth::Byte) => "%dl",
 
-            (IntegerRegister::SI, OperandWidth::QuadWord) => "rsi",
-            (IntegerRegister::SI, OperandWidth::DoubleWord) => "esi",
-            (IntegerRegister::SI, OperandWidth::Word) => "si",
-            (IntegerRegister::SI, OperandWidth::Byte) => "sil",
-            (IntegerRegister::DI, OperandWidth::QuadWord) => "rdi",
-            (IntegerRegister::DI, OperandWidth::DoubleWord) => "edi",
-            (IntegerRegister::DI, OperandWidth::Word) => "di",
-            (IntegerRegister::DI, OperandWidth::Byte) => "dil",
-            (IntegerRegister::BP, OperandWidth::QuadWord) => "rbp",
-            (IntegerRegister::BP, OperandWidth::DoubleWord) => "ebp",
-            (IntegerRegister::BP, OperandWidth::Word) => "bp",
-            (IntegerRegister::BP, OperandWidth::Byte) => "bpl",
-            (IntegerRegister::SP, OperandWidth::QuadWord) => "rsp",
-            (IntegerRegister::SP, OperandWidth::DoubleWord) => "esp",
-            (IntegerRegister::SP, OperandWidth::Word) => "sp",
-            (IntegerRegister::SP, OperandWidth::Byte) => "spl",
-            (IntegerRegister::R8, OperandWidth::QuadWord) => "r8",
-            (IntegerRegister::R8, OperandWidth::DoubleWord) => "r8d",
-            (IntegerRegister::R8, OperandWidth::Word) => "r8w",
-            (IntegerRegister::R8, OperandWidth::Byte) => "r8b",
-            (IntegerRegister::R9, OperandWidth::QuadWord) => "r9",
-            (IntegerRegister::R9, OperandWidth::DoubleWord) => "r9d",
-            (IntegerRegister::R9, OperandWidth::Word) => "r9w",
-            (IntegerRegister::R9, OperandWidth::Byte) => "r9b",
-            (IntegerRegister::R10, OperandWidth::QuadWord) => "r10",
-            (IntegerRegister::R10, OperandWidth::DoubleWord) => "r10d",
-            (IntegerRegister::R10, OperandWidth::Word) => "r10w",
-            (IntegerRegister::R10, OperandWidth::Byte) => "r10b",
-            (IntegerRegister::R11, OperandWidth::QuadWord) => "r11",
-            (IntegerRegister::R11, OperandWidth::DoubleWord) => "r11d",
-            (IntegerRegister::R11, OperandWidth::Word) => "r11w",
-            (IntegerRegister::R11, OperandWidth::Byte) => "r11b",
-            (IntegerRegister::R12, OperandWidth::QuadWord) => "r12",
-            (IntegerRegister::R12, OperandWidth::DoubleWord) => "r12d",
-            (IntegerRegister::R12, OperandWidth::Word) => "r12w",
-            (IntegerRegister::R12, OperandWidth::Byte) => "r12b",
-            (IntegerRegister::R13, OperandWidth::QuadWord) => "r13",
-            (IntegerRegister::R13, OperandWidth::DoubleWord) => "r13d",
-            (IntegerRegister::R13, OperandWidth::Word) => "r13w",
-            (IntegerRegister::R13, OperandWidth::Byte) => "r13b",
-            (IntegerRegister::R14, OperandWidth::QuadWord) => "r14",
-            (IntegerRegister::R14, OperandWidth::DoubleWord) => "r14d",
-            (IntegerRegister::R14, OperandWidth::Word) => "r14w",
-            (IntegerRegister::R14, OperandWidth::Byte) => "r14b",
-            (IntegerRegister::R15, OperandWidth::QuadWord) => "r15",
-            (IntegerRegister::R15, OperandWidth::DoubleWord) => "r15d",
-            (IntegerRegister::R15, OperandWidth::Word) => "r15w",
-            (IntegerRegister::R15, OperandWidth::Byte) => "r15b",
+            (IntegerRegister::SI, OperandWidth::QuadWord) => "%rsi",
+            (IntegerRegister::SI, OperandWidth::DoubleWord) => "%esi",
+            (IntegerRegister::SI, OperandWidth::Word) => "%si",
+            (IntegerRegister::SI, OperandWidth::Byte) => "%sil",
+            (IntegerRegister::DI, OperandWidth::QuadWord) => "%rdi",
+            (IntegerRegister::DI, OperandWidth::DoubleWord) => "%edi",
+            (IntegerRegister::DI, OperandWidth::Word) => "%di",
+            (IntegerRegister::DI, OperandWidth::Byte) => "%dil",
+            (IntegerRegister::BP, OperandWidth::QuadWord) => "%rbp",
+            (IntegerRegister::BP, OperandWidth::DoubleWord) => "%ebp",
+            (IntegerRegister::BP, OperandWidth::Word) => "%bp",
+            (IntegerRegister::BP, OperandWidth::Byte) => "%bpl",
+            (IntegerRegister::SP, OperandWidth::QuadWord) => "%rsp",
+            (IntegerRegister::SP, OperandWidth::DoubleWord) => "%esp",
+            (IntegerRegister::SP, OperandWidth::Word) => "%sp",
+            (IntegerRegister::SP, OperandWidth::Byte) => "%spl",
+            (IntegerRegister::R8, OperandWidth::QuadWord) => "%r8",
+            (IntegerRegister::R8, OperandWidth::DoubleWord) => "%r8d",
+            (IntegerRegister::R8, OperandWidth::Word) => "%r8w",
+            (IntegerRegister::R8, OperandWidth::Byte) => "%r8b",
+            (IntegerRegister::R9, OperandWidth::QuadWord) => "%r9",
+            (IntegerRegister::R9, OperandWidth::DoubleWord) => "%r9d",
+            (IntegerRegister::R9, OperandWidth::Word) => "%r9w",
+            (IntegerRegister::R9, OperandWidth::Byte) => "%r9b",
+            (IntegerRegister::R10, OperandWidth::QuadWord) => "%r10",
+            (IntegerRegister::R10, OperandWidth::DoubleWord) => "%r10d",
+            (IntegerRegister::R10, OperandWidth::Word) => "%r10w",
+            (IntegerRegister::R10, OperandWidth::Byte) => "%r10b",
+            (IntegerRegister::R11, OperandWidth::QuadWord) => "%r11",
+            (IntegerRegister::R11, OperandWidth::DoubleWord) => "%r11d",
+            (IntegerRegister::R11, OperandWidth::Word) => "%r11w",
+            (IntegerRegister::R11, OperandWidth::Byte) => "%r11b",
+            (IntegerRegister::R12, OperandWidth::QuadWord) => "%r12",
+            (IntegerRegister::R12, OperandWidth::DoubleWord) => "%r12d",
+            (IntegerRegister::R12, OperandWidth::Word) => "%r12w",
+            (IntegerRegister::R12, OperandWidth::Byte) => "%r12b",
+            (IntegerRegister::R13, OperandWidth::QuadWord) => "%r13",
+            (IntegerRegister::R13, OperandWidth::DoubleWord) => "%r13d",
+            (IntegerRegister::R13, OperandWidth::Word) => "%r13w",
+            (IntegerRegister::R13, OperandWidth::Byte) => "%r13b",
+            (IntegerRegister::R14, OperandWidth::QuadWord) => "%r14",
+            (IntegerRegister::R14, OperandWidth::DoubleWord) => "%r14d",
+            (IntegerRegister::R14, OperandWidth::Word) => "%r14w",
+            (IntegerRegister::R14, OperandWidth::Byte) => "%r14b",
+            (IntegerRegister::R15, OperandWidth::QuadWord) => "%r15",
+            (IntegerRegister::R15, OperandWidth::DoubleWord) => "%r15d",
+            (IntegerRegister::R15, OperandWidth::Word) => "%r15w",
+            (IntegerRegister::R15, OperandWidth::Byte) => "%r15b",
         }
     }
 }
@@ -178,6 +179,14 @@ impl WidthFormatted for GeneralPurposeRegister {
     }
 }
 
+impl WidthFormatted for &GeneralPurposeRegister {
+    type Output = &'static str;
+
+    fn fmt_with_operand_width(&self, width: OperandWidth) -> Self::Output {
+        IntegerRegister::from(**self).fmt_with_operand_width(width)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct RegisterAllocationGuard {
     free_channel: std::sync::mpsc::Sender<GeneralPurposeRegister>,
@@ -194,6 +203,14 @@ impl RegisterAllocationGuard {
 
     pub(crate) fn borrow_inner(&self) -> &GeneralPurposeRegister {
         &self.reg
+    }
+}
+
+impl WidthFormatted for RegisterAllocationGuard {
+    type Output = &'static str;
+
+    fn fmt_with_operand_width(&self, width: OperandWidth) -> Self::Output {
+        self.reg.fmt_with_operand_width(width)
     }
 }
 

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -481,7 +481,7 @@ fn codegen_inc_or_dec_expression_from_pointer<OP: Operand>(
                         ),
                         op,
                     ],
-                    codegen_deref(ret_val, ty, 0),
+                    codegen_deref(ty, ret_val, 0),
                 )
             }
             IncDecExpression::PostIncrement | IncDecExpression::PostDecrement => {
@@ -492,7 +492,7 @@ fn codegen_inc_or_dec_expression_from_pointer<OP: Operand>(
                         ret_val.fmt_with_operand_width(OperandWidth::QuadWord),
                         ptr_reg.fmt_with_operand_width(OperandWidth::QuadWord)
                     )],
-                    codegen_deref(ret_val, ty, 0),
+                    codegen_deref(ty, ret_val, 0),
                     vec![op],
                 )
             }
@@ -893,7 +893,7 @@ fn codegen_expr<OP: Operand>(
         TypedExprNode::Deref(ty, expr) => {
             flattenable_instructions!(
                 codegen_expr(allocator, ret_val, *expr),
-                codegen_deref(ret_val, ty, 0),
+                codegen_deref(ty, ret_val, 0),
             )
         }
         TypedExprNode::ScaleBy(ty, lhs) => {
@@ -1023,7 +1023,7 @@ where
     )]
 }
 
-fn codegen_deref<OP: Operand>(ret: &OP, ty: ast::Type, scale: usize) -> Vec<String> {
+fn codegen_deref<OP: Operand>(ty: ast::Type, ret: &OP, scale: usize) -> Vec<String> {
     let scale_by = ty.size() * scale;
     let width = operand_width_of_type(ty);
 

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -405,7 +405,8 @@ fn codegen_load_local(
     offset: isize,
     scale: usize,
 ) -> Vec<String> {
-    let scale_by = ty.size() * scale;
+    let scale_by = -((ty.size() * scale) as isize);
+    /*
     let width = operand_width_of_type(ty);
 
     if scale == 0 {
@@ -426,6 +427,11 @@ fn codegen_load_local(
             ret.fmt_with_operand_width(width)
         )]
     }
+    */
+
+    let scaled_offset = offset + scale_by;
+    *ret = RegisterOrOffset::Offset(scaled_offset);
+    vec![]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stage/type_check/ast/mod.rs
+++ b/src/stage/type_check/ast/mod.rs
@@ -86,12 +86,6 @@ impl TypedFunctionDeclaration {
             local_vars,
         }
     }
-
-    /* fix me
-    pub fn alignment(&self) -> isize {
-        (self.local_variable_size + 15) & !15
-    }
-    */
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -592,22 +592,19 @@ impl TypeAnalysis {
 
             ExprNode::BitOr(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
-                .map(|(_, lhs, rhs)| {
-                    let ty = ast::Type::Integer(ast::Signed::Unsigned, ast::IntegerWidth::One);
+                .map(|(ty, lhs, rhs)| {
                     ast::TypedExprNode::BitOr(ty, Box::new(lhs), Box::new(rhs))
                 })
                 .ok_or_else(|| "incompatible types for bitwise or operation".to_string()),
             ExprNode::BitXor(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
-                .map(|(_, lhs, rhs)| {
-                    let ty = ast::Type::Integer(ast::Signed::Unsigned, ast::IntegerWidth::One);
+                .map(|(ty, lhs, rhs)| {
                     ast::TypedExprNode::BitXor(ty, Box::new(lhs), Box::new(rhs))
                 })
                 .ok_or_else(|| "incompatible types for bitwise xor operation".to_string()),
             ExprNode::BitAnd(lhs, rhs) => self
                 .analyze_binary_expr(*lhs, *rhs)
-                .map(|(_, lhs, rhs)| {
-                    let ty = ast::Type::Integer(ast::Signed::Unsigned, ast::IntegerWidth::One);
+                .map(|(ty, lhs, rhs)| {
                     ast::TypedExprNode::BitAnd(ty, Box::new(lhs), Box::new(rhs))
                 })
                 .ok_or_else(|| "incompatible types for bitwise and operation".to_string()),


### PR DESCRIPTION
# Introduction
This PR introduces the ability to use local references without a `mov` when applicable. This is accomplished by allowing a generation stages allocated return register to be downgraded to to an address offset at any point of it's allocation.

# Linked Issues
resolves #128 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
