### PR TITLE
Char literal type should match char type specifier

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1067,7 +1067,7 @@ mod tests {
             .map(|ms| ms.unwrap());
 
         let expected_result = Ok(CompoundStmts::new(vec![StmtNode::Expression(
-            primary_expr!(u8 97),
+            primary_expr!(i8 97),
         )]));
 
         assert_eq!(&expected_result, &res);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -609,7 +609,7 @@ fn string_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary>
 
 fn character_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
     character_wrapped('\'', '\'', ascii().map(|c| c as u8)).map(|num| Primary::Integer {
-        sign: Signed::Unsigned,
+        sign: Signed::Signed,
         width: IntegerWidth::Eight,
         value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
     })


### PR DESCRIPTION
# Introduction
Mistakenly, the char literal was an unsigned 8-bit integer while the specifier was a signed 8-bit integer. This PR unifies the two to a signed 8-bit integer, the lower of the two ranks in the type-checker.
# Linked Issues
resolves #133 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
