### PR TITLE
Implement function prototypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /target/
 *.s
 *.out
+*.o
 *.c
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /target/
 *.s
 *.out
+*.c
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ Grammar is heavily referenced from [WMU cs4850 course grammar](https://cs.wmich.
 tranlation_unit: external_declaration*
         ;
 
-external_declaration: function_declaration
+external_declaration: function_definition 
+        | function_prototype ';'
         | var_declaration
         ;
 
 function_prototype: type_declarator identifier '(' ((type_declarator identifier,)* type_declarator identifier) | (type_declarator identifier) ')'
         ;
 
-function_declaration: function_prototype compound_statement
+function_definition: function_prototype compound_statement
         ;
 
 compound_statement: '{' '}'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ external_declaration: function_declaration
         | var_declaration
         ;
 
-function_declaration: type_declarator identifier '(' ((type_declarator identifier,)* type_declarator identifier) | (type_declarator identifier) ')' compound_statement
+function_prototype: type_declarator identifier '(' ((type_declarator identifier,)* type_declarator identifier) | (type_declarator identifier) ')'
+        ;
+
+function_declaration: function_prototype compound_statement
         ;
 
 compound_statement: '{' '}'

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -21,7 +21,8 @@ impl CompilationUnit {
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum GlobalDecls {
-    Func(FunctionDeclaration),
+    FuncDefinition(FunctionDefinition),
+    FuncProto(FunctionProto),
     Var(Declaration),
 }
 
@@ -56,12 +57,12 @@ impl FunctionProto {
 
 /// A new fuction declaration wrapping a string and block.
 #[derive(PartialEq, Debug, Clone)]
-pub struct FunctionDeclaration {
+pub struct FunctionDefinition {
     pub proto: FunctionProto,
     pub block: CompoundStmts,
 }
 
-impl FunctionDeclaration {
+impl FunctionDefinition {
     pub fn new(proto: FunctionProto, block: CompoundStmts) -> Self {
         Self { proto, block }
     }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -37,28 +37,33 @@ impl Parameter {
     }
 }
 
-/// A new fuction declaration wrapping a string and block.
 #[derive(PartialEq, Debug, Clone)]
-pub struct FunctionDeclaration {
+pub struct FunctionProto {
     pub id: String,
     pub return_type: ast::Type,
     pub params: Vec<Parameter>,
+}
+
+impl FunctionProto {
+    pub fn new(id: String, return_type: ast::Type, params: Vec<Parameter>) -> Self {
+        Self {
+            id,
+            return_type,
+            params,
+        }
+    }
+}
+
+/// A new fuction declaration wrapping a string and block.
+#[derive(PartialEq, Debug, Clone)]
+pub struct FunctionDeclaration {
+    pub proto: FunctionProto,
     pub block: CompoundStmts,
 }
 
 impl FunctionDeclaration {
-    pub fn new(
-        id: String,
-        return_type: ast::Type,
-        params: Vec<Parameter>,
-        block: CompoundStmts,
-    ) -> Self {
-        Self {
-            id,
-            params,
-            return_type,
-            block,
-        }
+    pub fn new(proto: FunctionProto, block: CompoundStmts) -> Self {
+        Self { proto, block }
     }
 }
 

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -65,6 +65,8 @@ impl CompilationStage<ast::TypedProgram, Vec<String>, String> for X86_64 {
                     ast::TypedGlobalDecls::Var(ast::Declaration::Array { ty, id, size }) => {
                         Ok(codegen_global_symbol(&ty, &id, size))
                     }
+                    // Prototypes are dropped at the typecheck and are effectively no-ops.
+                    ast::TypedGlobalDecls::FuncProto => Ok(vec![]),
                 };
 
                 res
@@ -1942,7 +1944,7 @@ fn operand_width_of_type(ty: ast::Type) -> OperandWidth {
             ast::IntegerWidth::ThirtyTwo => OperandWidth::DoubleWord,
             ast::IntegerWidth::SixtyFour => OperandWidth::QuadWord,
         },
-        Type::Void | Type::Func(_) | Type::Pointer(_) => OperandWidth::QuadWord,
+        Type::Void | Type::Func(_, _) | Type::Pointer(_) => OperandWidth::QuadWord,
     }
 }
 

--- a/src/stage/type_check/ast/mod.rs
+++ b/src/stage/type_check/ast/mod.rs
@@ -343,12 +343,12 @@ impl ByteSized for IntegerWidth {
 
 /// A concrete type for function prototypes
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FuncProto {
+pub struct FunctionSignature {
     pub return_type: Box<Type>,
     pub parameters: Vec<Parameter>,
 }
 
-impl FuncProto {
+impl FunctionSignature {
     pub fn new(return_type: Box<Type>, parameters: Vec<Parameter>) -> Self {
         Self {
             return_type,
@@ -365,7 +365,7 @@ const POINTER_BYTE_WIDTH: usize = (usize::BITS / 8) as usize;
 pub enum Type {
     Integer(Signed, IntegerWidth),
     Void,
-    Func(FuncProto),
+    Func(FunctionSignature),
     Pointer(Box<Type>),
 }
 

--- a/src/stage/type_check/ast/mod.rs
+++ b/src/stage/type_check/ast/mod.rs
@@ -110,6 +110,7 @@ impl TypedFunctionDeclaration {
 #[derive(PartialEq, Debug, Clone)]
 pub enum TypedGlobalDecls {
     Func(TypedFunctionDeclaration),
+    FuncProto,
     Var(Declaration),
 }
 
@@ -341,6 +342,22 @@ impl ByteSized for IntegerWidth {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefinitionState {
+    Declared,
+    Defined,
+}
+
+impl DefinitionState {
+    pub fn is_defined(&self) -> bool {
+        matches!(self, DefinitionState::Defined)
+    }
+
+    pub fn is_declared(&self) -> bool {
+        matches!(self, DefinitionState::Declared)
+    }
+}
+
 /// A concrete type for function prototypes
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionSignature {
@@ -365,7 +382,7 @@ const POINTER_BYTE_WIDTH: usize = (usize::BITS / 8) as usize;
 pub enum Type {
     Integer(Signed, IntegerWidth),
     Void,
-    Func(FunctionSignature),
+    Func(DefinitionState, FunctionSignature),
     Pointer(Box<Type>),
 }
 

--- a/src/stage/type_check/mod.rs
+++ b/src/stage/type_check/mod.rs
@@ -554,7 +554,7 @@ impl TypeAnalysis {
                     .lookup(&identifier)
                     .ok_or_else(|| format!("undefined_function: {}", &identifier))
                     .and_then(|dm| match dm.r#type.clone() {
-                        ast::Type::Func(ast::DefinitionState::Defined, FunctionSignature {
+                        ast::Type::Func(_, FunctionSignature {
                             return_type,
                             parameters: params,
                         }) => {
@@ -593,10 +593,6 @@ impl TypeAnalysis {
                                 ))
                             }
                         }
-                        ast::Type::Func(ast::DefinitionState::Declared, _) => Err(format!(
-                            "function {} declared but not defined",
-                            &identifier
-                        )),
                         _ => Err(format!(
                             "type mismatch, cannot call non-function type: {:?}",
                             &dm.r#type


### PR DESCRIPTION
# Introduction
Introduce function prototypes as a distinction from declarations.

```c
// declaration
int test(int a);

// definition
int other_test(int a) {
    return a;
}
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
