### PR TITLE
Integrate assemble and link step into binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # mossy
 An (irresponsibly) experimental C compiler for the first-principles of computing project.
 
+## Running
+
+```bash
+$ cargo build && ./target/debug/mossy -i <file>
+```
+
 ## Pre-Processor
 The pre-processor provides for text replacement prior to parsing any context sensitive grammar.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::prelude::*;
+use std::path::{Path, PathBuf};
 use std::process;
 
 type RuntimeResult<T> = Result<T, RuntimeError>;
@@ -12,7 +13,7 @@ const DEFAULT_ASSEMBLER: &str = "/usr/bin/as";
 const ASSEMBLER_FLAGS: &str = "";
 const LINKER_ENV_VAR: &str = "CC";
 const DEFAULT_LINKER: &str = "/usr/bin/cc";
-const LINKER_FLAGS: &str = "-O0 -o a";
+const LINKER_FLAGS: &str = "-O0";
 
 enum RuntimeError {
     FileUnreadable,
@@ -34,7 +35,7 @@ impl fmt::Display for RuntimeError {
     }
 }
 
-fn read_src_file(filename: &str) -> RuntimeResult<String> {
+fn read_src_file<P: AsRef<Path>>(filename: P) -> RuntimeResult<String> {
     let mut f = File::open(filename).map_err(|_| RuntimeError::FileUnreadable)?;
 
     let mut contents = String::new();
@@ -44,7 +45,7 @@ fn read_src_file(filename: &str) -> RuntimeResult<String> {
     }
 }
 
-fn write_dest_file(filename: &str, data: &[u8]) -> RuntimeResult<()> {
+fn write_dest_file<P: AsRef<Path>>(filename: P, data: &[u8]) -> RuntimeResult<()> {
     let mut f = OpenOptions::new()
         .truncate(true)
         .create(true)
@@ -79,30 +80,38 @@ fn compile(source: &str) -> RuntimeResult<String> {
         .map_err(RuntimeError::Undefined)
 }
 
-fn assemble<'a, S>(filename: S) -> RuntimeResult<&'a str>
+fn assemble<P>(filename: P) -> RuntimeResult<PathBuf>
 where
-    S: AsRef<std::ffi::OsStr>,
+    P: AsRef<Path>,
 {
+    // convert the filepath to a .out file.
+    let output_filename = filename.as_ref().with_extension("out");
+
     process::Command::new(
         env::var(ASSEMBLER_ENV_VAR).unwrap_or_else(|_| DEFAULT_ASSEMBLER.to_string()),
     )
     .args(ASSEMBLER_FLAGS.split_whitespace())
-    .arg(filename)
+    .args(format!("-o {}", &output_filename.display()).split_whitespace())
+    .arg(filename.as_ref().as_os_str())
     .output()
-    .map(|_| "a.out")
+    .map(|_| output_filename)
     .map_err(|e| RuntimeError::Undefined(e.to_string()))
 }
 
-fn link<'a, S>(filenames: &[S]) -> RuntimeResult<&'a str>
+fn link<I, O>(output_file: O, filenames: &[I]) -> RuntimeResult<()>
 where
-    S: AsRef<std::ffi::OsStr>,
+    I: AsRef<Path>,
+    O: AsRef<Path>,
 {
     process::Command::new(env::var(LINKER_ENV_VAR).unwrap_or_else(|_| DEFAULT_LINKER.to_string()))
         .args(LINKER_FLAGS.split_whitespace())
+        .args(
+            format!("-o {}", &output_file.as_ref().with_extension("").display()).split_whitespace(),
+        )
         // output binary
-        .args(filenames)
+        .args(filenames.iter().map(|f| f.as_ref().as_os_str()))
         .output()
-        .map(|_| "a")
+        .map(|_| ())
         .map_err(|e| RuntimeError::Undefined(e.to_string()))
 }
 
@@ -113,9 +122,7 @@ fn main() -> RuntimeResult<()> {
     // Flag Definitions
     let help = scrap::Flag::store_true("help", "h", "display usage information.").optional();
     let in_file = scrap::Flag::expect_string("in-file", "i", "an input path for a source file.");
-    let out_file = scrap::Flag::expect_string("out-file", "o", "an assembly output path.")
-        .optional()
-        .with_default("a.s".to_string());
+    let out_file = scrap::Flag::expect_string("out-file", "o", "a binary output path.").optional();
     let backend = scrap::Flag::with_choices(
         "backend",
         "b",
@@ -135,18 +142,24 @@ fn main() -> RuntimeResult<()> {
         .with_flag(backend)
         .with_flag(help)
         .with_handler(|(((inf, ouf), _), _)| {
-            read_src_file(&inf)
+            let input_file = Path::new(&inf);
+
+            read_src_file(input_file)
                 .and_then(|input| compile(&input))
-                .and_then(|asm| write_dest_file(&ouf, asm.as_bytes()))
-                .and_then(|_| assemble(&ouf))
+                .and_then(|asm| {
+                    let asm_out_file = input_file.with_extension("s");
+                    write_dest_file(&asm_out_file, asm.as_bytes()).map(|_| asm_out_file)
+                })
+                .and_then(|asm_src| assemble(&asm_src))
+                .map(|out_file| ouf.map_or(out_file, |f| Path::new(&f).to_path_buf()))
                 .and_then(|bin_out| {
-                    let bins = [bin_out, "./utils/print_int.o", "./utils/print_char.o"];
-                    link(&bins)
+                    let bins = [&bin_out, &Path::new("./utils/print_utils.o").to_path_buf()];
+                    link(&bin_out, &bins)
                 })
         });
 
     cmd.evaluate(&args[..])
-        .map_err(|e| RuntimeError::Undefined(e.to_string()))
+        .map_err(|e| RuntimeError::Undefined(format!("{}\n{}", e.to_string(), cmd.help())))
         .and_then(|(flags, help)| {
             if help.is_some() {
                 println!("{}", cmd.help());


### PR DESCRIPTION
# Introduction
This PR pulls the assemble and link stages into the binary... currently this requires hardcoding link lib path into the main binary, which I hate. And I would like to use this draft to both drive adding positional args to scrap and to play with the UX of the command line args. Most likely I will drift towards the clang/gcc arg format.

## Currently

```bash
$ ./target/debug/mossy -i test.c
```
# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
