### PR TITLE
add cargo flamegraph

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,12 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list \
+	&& echo 'deb-src http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list \
+	&& apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+	linux-perf-5.15

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,20 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust
 {
 	"name": "Rust",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+			// Use bullseye when on local on arm64/Apple Silicon.
+			"VARIANT": "bullseye"
+		}
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
 		"--security-opt",
 		"seccomp=unconfined"
 	],
-
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"lldb.executable": "/usr/bin/lldb",
@@ -20,7 +24,6 @@
 		},
 		"rust-analyzer.checkOnSave.command": "clippy"
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"vadimcn.vscode-lldb",
@@ -29,13 +32,10 @@
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"postCreateCommand": "cargo install flamegraph",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ An (irresponsibly) experimental C compiler for the first-principles of computing
 $ cargo build && ./target/debug/mossy -i <file>
 ```
 
+## Flamegraph
+
+```
+cargo flamegraph -- ./target/debug/mossy -i <file>
+```
+
 ## Pre-Processor
 The pre-processor provides for text replacement prior to parsing any context sensitive grammar.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ fn main() -> RuntimeResult<()> {
         });
 
     cmd.evaluate(&args[..])
-        .map_err(|e| RuntimeError::Undefined(format!("{}\n{}", &e, cmd.help())))
+        .map_err(|e| RuntimeError::Undefined(format!("{}\n{}", e, cmd.help())))
         .and_then(|(flags, help)| {
             if help.is_some() {
                 println!("{}", cmd.help());

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ fn main() -> RuntimeResult<()> {
         });
 
     cmd.evaluate(&args[..])
-        .map_err(|e| RuntimeError::Undefined(format!("{}\n{}", e.to_string(), cmd.help())))
+        .map_err(|e| RuntimeError::Undefined(format!("{}\n{}", &e, cmd.help())))
         .and_then(|(flags, help)| {
             if help.is_some() {
                 println!("{}", cmd.help());


### PR DESCRIPTION
# Introduction
Small PR to add cargo-flamegraph to the dev container. Your mileage may vary depending on the kernel you are using as it depends on perf.
# Linked Issues
resolves #148 
# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
