### PR TITLE
Update branch triggers in ci from master to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: 
   push:
     branches:
-      - master
+      - main
   pull_request:
   release:
     types:


### PR DESCRIPTION
# Introduction
The default branch was changed from `master` -> `main` a while back but the branch triggers for the test actions were not updated along with it. This PR corrects that.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
