### PR TITLE
Split out lexer stage from parser

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -30,6 +30,7 @@ pub enum TokenType {
     Minus,
     Star,
     Slash,
+    PercentSign,
 
     // Other operators
     Tilde,
@@ -91,6 +92,7 @@ pub enum Token {
     Minus,
     Star,
     Slash,
+    PercentSign,
 
     // Other operators
     Tilde,
@@ -151,6 +153,7 @@ impl Token {
             Token::Minus => TokenType::Minus,
             Token::Star => TokenType::Star,
             Token::Slash => TokenType::Slash,
+            Token::PercentSign => TokenType::PercentSign,
             Token::Tilde => TokenType::Tilde,
             Token::PlusPlus => TokenType::PlusPlus,
             Token::MinusMinus => TokenType::MinusMinus,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,0 +1,756 @@
+mod stack;
+
+/// Defines the wrapper type for an error returned from Lexing
+type LexError = String;
+
+/// Lex returns either a
+pub type LexResult = Result<Vec<Token>, LexError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenType {
+    Eof,
+
+    // Binary operators
+    Equal,
+    EqualEqual,
+    Pipe,
+    PipePipe,
+    Ampersand,
+    AmpersandAmpersand,
+    Carat,
+    Bang,
+    BangEqual,
+    LessThan,
+    GreaterThan,
+    LessEqual,
+    GreaterEqual,
+    LShift,
+    RShift,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+
+    // Other operators
+    Tilde,
+    PlusPlus,
+    MinusMinus,
+
+    // Type keywords
+    Void,
+    Char,
+    Short,
+    Int,
+    Long,
+
+    // Other keywords
+    If,
+    Else,
+    While,
+    For,
+    Return,
+
+    // Structural tokens
+    CharLiteral,
+    IntLiteral,
+    StrLiteral,
+    SemiColon,
+    Identifier,
+    LBrace,
+    RBrace,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    Comma,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Token {
+    Eof,
+
+    // Binary operators
+    Equal,
+    EqualEqual,
+    Pipe,
+    PipePipe,
+    Ampersand,
+    AmpersandAmperand,
+    Carat,
+    Bang,
+    BangEqual,
+    LessThan,
+    GreaterThan,
+    LessEqual,
+    GreaterEqual,
+    LShift,
+    RShift,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+
+    // Other operators
+    Tilde,
+    PlusPlus,
+    MinusMinus,
+
+    // Type keywords
+    Void,
+    Char,
+    Short,
+    Int,
+    Long,
+
+    // Other keywords
+    If,
+    Else,
+    While,
+    For,
+    Return,
+
+    // Structural tokens
+    CharLiteral(char),
+    IntLiteral(isize),
+    StrLiteral(String),
+    Identifier(String),
+    SemiColon,
+    LBrace,
+    RBrace,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    Comma,
+}
+
+impl Token {
+    pub fn to_token_type(&self) -> TokenType {
+        match self {
+            Token::Eof => TokenType::Eof,
+            Token::Equal => TokenType::Equal,
+            Token::Pipe => TokenType::Pipe,
+            Token::AmpersandAmperand => TokenType::AmpersandAmpersand,
+            Token::PipePipe => TokenType::PipePipe,
+            Token::Carat => TokenType::Carat,
+            Token::Ampersand => TokenType::Ampersand,
+            Token::EqualEqual => TokenType::EqualEqual,
+            Token::Bang => TokenType::Bang,
+            Token::BangEqual => TokenType::BangEqual,
+            Token::LessThan => TokenType::LessThan,
+            Token::GreaterThan => TokenType::GreaterThan,
+            Token::LessEqual => TokenType::LessEqual,
+            Token::GreaterEqual => TokenType::GreaterEqual,
+            Token::LShift => TokenType::LShift,
+            Token::RShift => TokenType::RShift,
+            Token::Plus => TokenType::Plus,
+            Token::Minus => TokenType::Minus,
+            Token::Star => TokenType::Star,
+            Token::Slash => TokenType::Slash,
+            Token::Tilde => TokenType::Tilde,
+            Token::PlusPlus => TokenType::PlusPlus,
+            Token::MinusMinus => TokenType::MinusMinus,
+            Token::Void => TokenType::Void,
+            Token::Char => TokenType::Char,
+            Token::Short => TokenType::Short,
+            Token::Int => TokenType::Int,
+            Token::Long => TokenType::Long,
+            Token::If => TokenType::If,
+            Token::Else => TokenType::Else,
+            Token::While => TokenType::While,
+            Token::For => TokenType::For,
+            Token::Return => TokenType::Return,
+            Token::CharLiteral(_) => TokenType::CharLiteral,
+            Token::IntLiteral(_) => TokenType::IntLiteral,
+            Token::StrLiteral(_) => TokenType::StrLiteral,
+            Token::Identifier(_) => TokenType::Identifier,
+            Token::SemiColon => TokenType::SemiColon,
+            Token::LBrace => TokenType::LBrace,
+            Token::RBrace => TokenType::RBrace,
+            Token::LParen => TokenType::LParen,
+            Token::RParen => TokenType::RParen,
+            Token::LBracket => TokenType::LBracket,
+            Token::RBracket => TokenType::RBracket,
+            Token::Comma => TokenType::Comma,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Cursor {
+    index: usize,
+    col: usize,
+    line: usize,
+}
+
+impl Cursor {
+    pub fn increment_column_mut(&mut self) {
+        self.index += 1;
+        self.col += 1;
+    }
+
+    pub fn increment_line_mut(&mut self) {
+        self.index += 1;
+        self.line += 1;
+        self.col += 0;
+    }
+}
+
+impl Default for Cursor {
+    fn default() -> Self {
+        Self {
+            index: 0,
+            col: 0,
+            line: 1,
+        }
+    }
+}
+
+impl core::fmt::Display for Cursor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "line: {}, column: {}", self.line, self.col)
+    }
+}
+
+use std::iter::Iterator;
+
+const STACK_SIZE: usize = 4096;
+
+type LexerStack<const N: usize> = stack::Stack<TokenOrLexeme, N>;
+
+const TOKEN_OR_LEXEME_INITIALIZER: TokenOrLexeme = TokenOrLexeme::Lexeme('\x00');
+
+#[derive(Debug, Clone)]
+enum TokenOrLexeme {
+    Token(Token),
+    Lexeme(char),
+}
+
+impl TokenOrLexeme {
+    fn to_lexeme(&self) -> Option<char> {
+        match self {
+            TokenOrLexeme::Lexeme(c) => Some(*c),
+            TokenOrLexeme::Token(_) => None,
+        }
+    }
+}
+
+impl Default for TokenOrLexeme {
+    fn default() -> Self {
+        TOKEN_OR_LEXEME_INITIALIZER
+    }
+}
+
+macro_rules! token {
+    ($tok:expr) => {
+        TokenOrLexeme::Token($tok)
+    };
+}
+
+macro_rules! lexeme {
+    ($lexeme:literal) => {
+        TokenOrLexeme::Lexeme($lexeme)
+    };
+    ($lexeme:expr) => {
+        TokenOrLexeme::Lexeme($lexeme)
+    };
+}
+
+#[derive(Debug)]
+enum LexOperation<T> {
+    // the last n elements to pop off and the target type
+    Shift(T),
+    ShiftReduce(usize, T),
+    Reduce(usize, T),
+    NoFurtherRefinement,
+    Err(String),
+}
+
+fn lexeme_is_identifier_ascii() -> impl Fn(&TokenOrLexeme) -> bool {
+    move |tol: &TokenOrLexeme| matches!(tol, TokenOrLexeme::Lexeme(l) if l.is_ascii_alphanumeric() || *l == '_')
+}
+
+fn matches_rules<T>(src: &[T], pred: impl Fn(&T) -> bool) -> bool {
+    src.iter().all(pred)
+}
+
+fn stack_eval_to_token(stack: &[TokenOrLexeme], next: Option<char>) -> LexOperation<TokenOrLexeme> {
+    match (stack, next) {
+        // shift an empty stack
+        ([], Some(c)) => LexOperation::Shift(lexeme!(c)),
+
+        ([lexeme!('{')], _) => LexOperation::Reduce(1, token!(Token::LBrace)),
+        ([lexeme!('}')], _) => LexOperation::Reduce(1, token!(Token::RBrace)),
+        ([lexeme!('(')], _) => LexOperation::Reduce(1, token!(Token::LParen)),
+        ([lexeme!(')')], _) => LexOperation::Reduce(1, token!(Token::RParen)),
+        ([lexeme!('[')], _) => LexOperation::Reduce(1, token!(Token::LBracket)),
+        ([lexeme!(']')], _) => LexOperation::Reduce(1, token!(Token::RBracket)),
+        ([lexeme!(';')], _) => LexOperation::Reduce(1, token!(Token::SemiColon)),
+        ([lexeme!(',')], _) => LexOperation::Reduce(1, token!(Token::Comma)),
+
+        ([TokenOrLexeme::Token(Token::Equal)], Some('=')) => {
+            LexOperation::ShiftReduce(2, token!(Token::EqualEqual))
+        }
+        ([lexeme!('=')], _) => LexOperation::Reduce(1, token!(Token::Equal)),
+        ([TokenOrLexeme::Token(Token::Bang)], Some('=')) => {
+            LexOperation::ShiftReduce(2, token!(Token::BangEqual))
+        }
+        ([lexeme!('!')], _) => LexOperation::Reduce(1, token!(Token::Bang)),
+
+        ([TokenOrLexeme::Token(Token::GreaterThan)], Some('>')) => {
+            LexOperation::ShiftReduce(2, token!(Token::RShift))
+        }
+        ([TokenOrLexeme::Token(Token::GreaterThan)], Some('=')) => {
+            LexOperation::ShiftReduce(2, token!(Token::GreaterEqual))
+        }
+        ([lexeme!('>')], _) => LexOperation::Reduce(1, token!(Token::GreaterThan)),
+
+        ([TokenOrLexeme::Token(Token::LessThan)], Some('<')) => {
+            LexOperation::ShiftReduce(2, token!(Token::LShift))
+        }
+        ([TokenOrLexeme::Token(Token::LessThan)], Some('=')) => {
+            LexOperation::ShiftReduce(2, token!(Token::LessEqual))
+        }
+        ([lexeme!('<')], _) => LexOperation::Reduce(1, token!(Token::LessThan)),
+
+        ([TokenOrLexeme::Token(Token::Ampersand)], Some('&')) => {
+            LexOperation::ShiftReduce(2, token!(Token::AmpersandAmperand))
+        }
+        ([lexeme!('&')], _) => LexOperation::Reduce(1, token!(Token::Ampersand)),
+
+        ([TokenOrLexeme::Token(Token::Pipe)], Some('|')) => {
+            LexOperation::ShiftReduce(2, token!(Token::PipePipe))
+        }
+        ([lexeme!('|')], _) => LexOperation::Reduce(1, token!(Token::Pipe)),
+
+        ([lexeme!('^')], _) => LexOperation::Reduce(1, token!(Token::Carat)),
+        ([lexeme!('~')], _) => LexOperation::Reduce(1, token!(Token::Tilde)),
+
+        ([TokenOrLexeme::Token(Token::Plus)], Some('+')) => {
+            LexOperation::ShiftReduce(2, token!(Token::PlusPlus))
+        }
+        ([lexeme!('+')], _) => LexOperation::Reduce(1, token!(Token::Plus)),
+        ([TokenOrLexeme::Token(Token::Minus)], Some('-')) => {
+            LexOperation::ShiftReduce(2, token!(Token::MinusMinus))
+        }
+        ([lexeme!('-')], _) => LexOperation::Reduce(1, token!(Token::Minus)),
+
+        ([lexeme!('*')], _) => LexOperation::Reduce(1, token!(Token::Star)),
+        ([lexeme!('/')], _) => LexOperation::Reduce(1, token!(Token::Slash)),
+
+        ([lexeme!('\''), TokenOrLexeme::Lexeme(c), lexeme!('\'')], _) if c.is_ascii() => {
+            LexOperation::Reduce(3, token!(Token::CharLiteral(*c)))
+        }
+        ([lexeme!('\'')], Some(l)) if l.is_ascii() => LexOperation::Shift(lexeme!(l)),
+        ([lexeme!('\''), TokenOrLexeme::Lexeme(c)], Some('\'')) if c.is_ascii() => {
+            LexOperation::ShiftReduce(3, token!(Token::CharLiteral(*c)))
+        }
+
+        ([lexeme!('\"'), .., lexeme!('\\')], Some('\"')) => LexOperation::Shift(lexeme!('\"')),
+        ([lexeme!('\"'), inner @ ..], Some('\"')) => {
+            let inner_str = inner
+                .iter()
+                .flat_map(|tol| match tol {
+                    TokenOrLexeme::Token(_) => None,
+                    TokenOrLexeme::Lexeme(c) => Some(*c),
+                })
+                .collect();
+            let token_cnt = inner.len() + 2;
+            LexOperation::ShiftReduce(token_cnt, token!(Token::StrLiteral(inner_str)))
+        }
+        ([lexeme!('\"'), ..], Some(c)) => LexOperation::Shift(lexeme!(c)),
+
+        ([TokenOrLexeme::Lexeme(l)], _) if l.is_digit(10) => l
+            .to_digit(10)
+            .map(|d| d as isize)
+            .map(|lit| LexOperation::Reduce(1, token!(Token::IntLiteral(lit))))
+            .unwrap_or_else(|| LexOperation::Err(format!("Unable to convert {} to digit", l))),
+        ([TokenOrLexeme::Token(Token::IntLiteral(_))], Some(l)) if l.is_digit(10) => {
+            LexOperation::Shift(lexeme!(l))
+        }
+        ([TokenOrLexeme::Token(Token::IntLiteral(base_int_lit)), TokenOrLexeme::Lexeme(l)], _)
+            if l.is_digit(10) =>
+        {
+            l.to_digit(10)
+                .map(|d| d as isize)
+                .map(|next| {
+                    // This match guarantees there is atleast a base.
+                    // if that base is < 10 we need to scale it.
+                    let unadjusted_multiplier = (base_int_lit / 10) as u32;
+                    let multiplier = if unadjusted_multiplier == 0 {
+                        1
+                    } else {
+                        unadjusted_multiplier
+                    };
+
+                    let scaled_base = base_int_lit * 10isize.pow(multiplier);
+                    let new_lit = scaled_base + next;
+
+                    LexOperation::Reduce(2, token!(Token::IntLiteral(new_lit)))
+                })
+                .unwrap_or_else(|| LexOperation::Err(format!("Unable to convert {} to digit", l)))
+        }
+
+        // Identifiers
+        ([contents @ ..], Some(l))
+            if matches_rules(contents, lexeme_is_identifier_ascii())
+                && matches_rules(&[lexeme!(l)], lexeme_is_identifier_ascii()) =>
+        {
+            LexOperation::Shift(lexeme!(l))
+        }
+        // if lookahead doesn't match an identifier reduce
+        ([contents @ ..], Some(l))
+            if matches_rules(contents, lexeme_is_identifier_ascii())
+                && !matches_rules(&[lexeme!(l)], lexeme_is_identifier_ascii()) =>
+        {
+            LexOperation::Reduce(
+                contents.len(),
+                token!(Token::Identifier(
+                    contents
+                        .iter()
+                        .flat_map(|tol| tol.to_lexeme())
+                        .collect::<String>()
+                )),
+            )
+        }
+        // if lookahead is empty, reduce.
+        ([contents @ ..], None) if matches_rules(contents, lexeme_is_identifier_ascii()) => {
+            LexOperation::Reduce(
+                contents.len(),
+                token!(Token::Identifier(
+                    contents
+                        .iter()
+                        .flat_map(|tol| tol.to_lexeme())
+                        .collect::<String>()
+                )),
+            )
+        }
+
+        // Type Keywords
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "void" => {
+            LexOperation::Reduce(1, token!(Token::Void))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "char" => {
+            LexOperation::Reduce(1, token!(Token::Char))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "short" => {
+            LexOperation::Reduce(1, token!(Token::Short))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "int" => {
+            LexOperation::Reduce(1, token!(Token::Int))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "long" => {
+            LexOperation::Reduce(1, token!(Token::Long))
+        }
+
+        // Other keywords
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "if" => {
+            LexOperation::Reduce(1, token!(Token::If))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "else" => {
+            LexOperation::Reduce(1, token!(Token::Else))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "for" => {
+            LexOperation::Reduce(1, token!(Token::For))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "while" => {
+            LexOperation::Reduce(1, token!(Token::While))
+        }
+
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "return" => {
+            LexOperation::Reduce(1, token!(Token::Return))
+        }
+
+        ([TokenOrLexeme::Token(_)], _) | ([.., TokenOrLexeme::Token(_)], _) => {
+            LexOperation::NoFurtherRefinement
+        }
+        ([.., TokenOrLexeme::Lexeme(c)], _) if c.is_whitespace() => {
+            LexOperation::Reduce(1, lexeme!(*c))
+        }
+
+        _ => LexOperation::Err("No rules matched with unpaired lexemes.".to_string()),
+    }
+}
+
+/// Scanner takes a string representing lox source and attempts to convert the
+/// source into a vector of either Tokens or lexical errors.
+pub struct Scanner<'a> {
+    source: core::iter::Peekable<core::str::Chars<'a>>,
+    cursor: Cursor,
+    stack: LexerStack<STACK_SIZE>,
+    end: usize,
+}
+
+fn consume_and_peek_from_iter<I>(iter: &mut core::iter::Peekable<I>) -> Option<char>
+where
+    I: Iterator<Item = char>,
+{
+    let _ = iter.next();
+    iter.peek().copied()
+}
+
+impl<'a> Scanner<'a> {
+    pub fn new(source: &'a str) -> Scanner<'a> {
+        let stack = LexerStack::new([TOKEN_OR_LEXEME_INITIALIZER; STACK_SIZE]);
+        let end = source.len();
+        Scanner {
+            source: source.chars().peekable(),
+            cursor: Cursor::default(),
+            stack,
+            end,
+        }
+    }
+
+    fn scan_token_from(&mut self) -> Result<Token, String> {
+        if self.source.peek().is_none() {
+            Ok(Token::Eof)
+        } else {
+            let mut lookahead = self.source.peek().copied();
+            loop {
+                let stack = self.stack.as_ref();
+                let op = stack_eval_to_token(stack, lookahead);
+
+                match op {
+                    LexOperation::Shift(TokenOrLexeme::Lexeme('\n')) => {
+                        // safe to unwrap due to is_some guarantee
+                        self.stack.push_mut(lexeme!('\n'));
+                        lookahead = consume_and_peek_from_iter(&mut self.source);
+                        self.cursor.increment_line_mut();
+                    }
+                    LexOperation::Shift(next_val) => {
+                        // safe to unwrap due to is_some guarantee
+                        self.stack.push_mut(next_val);
+                        lookahead = consume_and_peek_from_iter(&mut self.source);
+                        self.cursor.increment_column_mut();
+                    }
+                    LexOperation::ShiftReduce(by, TokenOrLexeme::Token(to_token)) => {
+                        lookahead = consume_and_peek_from_iter(&mut self.source);
+                        // pop n elements off the stack
+                        for _ in 0..by {
+                            self.stack.pop_mut();
+                        }
+
+                        self.stack.push_mut(TokenOrLexeme::Token(to_token));
+                        // safe to unwrap due to is_some guarantee
+                        self.cursor.increment_column_mut();
+                    }
+                    LexOperation::ShiftReduce(by, TokenOrLexeme::Lexeme('\n')) => {
+                        for _ in 0..by {
+                            self.stack.pop_mut();
+                        }
+                        self.cursor.increment_line_mut();
+                    }
+                    LexOperation::ShiftReduce(by, TokenOrLexeme::Lexeme(_)) => {
+                        for _ in 0..by {
+                            self.stack.pop_mut();
+                        }
+                        self.cursor.increment_column_mut();
+                    }
+                    LexOperation::Reduce(by, TokenOrLexeme::Lexeme('\n')) => {
+                        for _ in 0..by {
+                            self.stack.pop_mut();
+                        }
+                    }
+                    // this will only occur with whitespace
+                    LexOperation::Reduce(by, TokenOrLexeme::Lexeme(_)) => {
+                        for _ in 0..by {
+                            self.stack.pop_mut();
+                        }
+                    }
+
+                    LexOperation::Reduce(by, tol) => {
+                        // pop n elements off the stack
+                        for _ in 0..by {
+                            self.stack.pop_mut();
+                        }
+
+                        // push the new token and next lexeme onto the stack.
+                        self.stack.push_mut(tol);
+                    }
+                    LexOperation::NoFurtherRefinement => match self.stack.pop_mut() {
+                        Some(TokenOrLexeme::Token(tok)) => return Ok(tok),
+                        _ => return Err(format!("invalid token at {}", &self.cursor)),
+                    },
+
+                    LexOperation::Err(e) => return Err(format!("{} at {}", e, &self.cursor)),
+                }
+            }
+        }
+    }
+}
+
+impl<'a> IntoIterator for Scanner<'a> {
+    type Item = Result<Token, String>;
+    type IntoIter = ScannerIntoIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ScannerIntoIterator { scanner: self }
+    }
+}
+
+pub struct ScannerIntoIterator<'a> {
+    scanner: Scanner<'a>,
+}
+
+impl<'a> Iterator for ScannerIntoIterator<'a> {
+    type Item = Result<Token, String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.scanner.cursor.index;
+        if index < self.scanner.end {
+            let next = self.scanner.scan_token_from();
+            match next {
+                Ok(Token::Eof) => None,
+                lex_res @ Ok(_) => Some(lex_res),
+                lex_res @ Err(_) => Some(lex_res),
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// lex all tokens into a a result vector.
+///
+/// # Notes
+/// This requires a needless collect to prevent a stack error.
+#[allow(clippy::needless_collect)]
+pub fn lex(src: &str) -> LexResult {
+    let scanner = Scanner::new(src);
+    let tokens: Vec<Result<Token, LexError>> = scanner.into_iter().collect();
+    let collected_result: Result<Vec<Token>, String> = tokens.into_iter().collect();
+    collected_result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_scan_single_token() {
+        let inputs = ["{", " {", " { "];
+
+        for input in inputs {
+            let mut scanner = Scanner::new(input).into_iter();
+
+            assert_eq!(Some(Ok(Token::LBrace)), scanner.next())
+        }
+    }
+
+    #[test]
+    fn should_scan_compound_token() {
+        let input_expected = [
+            (["<", " <", " < "], Token::LessThan),
+            (["<=", " <=", " <= "], Token::LessEqual),
+        ];
+
+        for (inputs, expected) in input_expected {
+            for input in inputs {
+                let mut scanner = Scanner::new(input).into_iter();
+
+                assert_eq!(Some(Ok(expected.clone())), scanner.next())
+            }
+        }
+    }
+
+    #[test]
+    fn should_scan_digit_token() {
+        let input_expected = [
+            (["1", " 1", " 1 "], Token::IntLiteral(1)),
+            (["123", " 123", " 123 "], Token::IntLiteral(123)),
+        ];
+
+        for (inputs, expected) in input_expected {
+            for input in inputs {
+                let mut scanner = Scanner::new(input).into_iter();
+
+                assert_eq!(Some(Ok(expected.clone())), scanner.next())
+            }
+        }
+    }
+
+    #[test]
+    fn should_scan_char_literals() {
+        let input_expected = [
+            (["\'a\'"], Token::CharLiteral('a')),
+            ([" \'a\'"], Token::CharLiteral('a')),
+            ([" \'a\' "], Token::CharLiteral('a')),
+        ];
+
+        for (inputs, expected) in input_expected {
+            for input in inputs {
+                let mut scanner = Scanner::new(input).into_iter();
+
+                assert_eq!(Some(Ok(expected.clone())), scanner.next())
+            }
+        }
+    }
+
+    #[test]
+    fn should_scan_string_literals() {
+        let input_expected = [
+            (["\"hello\""], Token::StrLiteral("hello".to_string())),
+            ([" \"hello\""], Token::StrLiteral("hello".to_string())),
+            ([" \"hello\" "], Token::StrLiteral("hello".to_string())),
+        ];
+
+        for (inputs, expected) in input_expected {
+            for input in inputs {
+                let mut scanner = Scanner::new(input).into_iter();
+
+                assert_eq!(Some(Ok(expected.clone())), scanner.next())
+            }
+        }
+    }
+
+    #[test]
+    fn should_scan_identifier() {
+        let input_expected = [
+            (["test"], Token::Identifier("test".to_string())),
+            ([" test"], Token::Identifier("test".to_string())),
+            ([" test "], Token::Identifier("test".to_string())),
+        ];
+
+        for (inputs, expected) in input_expected {
+            for input in inputs {
+                let mut scanner = Scanner::new(input).into_iter();
+
+                assert_eq!(Some(Ok(expected.clone())), scanner.next())
+            }
+        }
+    }
+
+    #[test]
+    fn should_scan_keywords() {
+        let input_expected = [
+            (["for"], Token::For),
+            ([" for"], Token::For),
+            ([" for "], Token::For),
+        ];
+
+        for (inputs, expected) in input_expected {
+            for input in inputs {
+                let mut scanner = Scanner::new(input).into_iter();
+
+                assert_eq!(Some(Ok(expected.clone())), scanner.next())
+            }
+        }
+    }
+
+    #[test]
+    fn should_scan_multiple_tokens() {
+        let input = "{ 1 + 2; }";
+        let res = lex(input);
+
+        let expected: Result<Vec<_>, _> = Ok(vec![
+            Token::LBrace,
+            Token::IntLiteral(1),
+            Token::Plus,
+            Token::IntLiteral(2),
+            Token::SemiColon,
+            Token::RBrace,
+        ]);
+
+        assert_eq!(expected, res)
+    }
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -37,6 +37,8 @@ pub enum TokenType {
     MinusMinus,
 
     // Type keywords
+    Signed,
+    Unsigned,
     Void,
     Char,
     Short,
@@ -96,6 +98,8 @@ pub enum Token {
     MinusMinus,
 
     // Type keywords
+    Signed,
+    Unsigned,
     Void,
     Char,
     Short,
@@ -150,6 +154,8 @@ impl Token {
             Token::Tilde => TokenType::Tilde,
             Token::PlusPlus => TokenType::PlusPlus,
             Token::MinusMinus => TokenType::MinusMinus,
+            Token::Signed => TokenType::Signed,
+            Token::Unsigned => TokenType::Unsigned,
             Token::Void => TokenType::Void,
             Token::Char => TokenType::Char,
             Token::Short => TokenType::Short,
@@ -460,6 +466,12 @@ fn stack_eval_to_token(stack: &[TokenOrLexeme], next: Option<char>) -> LexOperat
         }
 
         // Type Keywords
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "signed" => {
+            LexOperation::Reduce(1, token!(Token::Signed))
+        }
+        ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "unsigned" => {
+            LexOperation::Reduce(1, token!(Token::Unsigned))
+        }
         ([TokenOrLexeme::Token(Token::Identifier(id))], _) if id == "void" => {
             LexOperation::Reduce(1, token!(Token::Void))
         }

--- a/src/lexer/stack.rs
+++ b/src/lexer/stack.rs
@@ -1,0 +1,87 @@
+#[derive(Debug, Clone)]
+pub struct Stack<T, const N: usize> {
+    head: usize,
+    data: [T; N],
+}
+
+// Generic constants
+impl<T, const N: usize> Stack<T, N> {
+    /// Represents the minimum index of the stack.
+    const MIN: usize = 0;
+
+    /// Represents the maximum index of the stack.
+    const MAX: usize = N - 1;
+}
+
+impl<T, const N: usize> Stack<T, N> {
+    /// Stack initializer type.
+    pub fn new(data: [T; N]) -> Self {
+        Self { head: 0, data }
+    }
+}
+
+impl<T: Default, const N: usize> Stack<T, N> {
+    pub fn empty(&self) -> bool {
+        self.head == Self::MIN
+    }
+
+    pub fn full(&self) -> bool {
+        self.head == Self::MAX
+    }
+
+    pub fn push_mut(&mut self, val: T) {
+        if self.full() {
+            panic!("stack overflow...")
+        } else {
+            let idx = self.head;
+            self.data[idx] = val;
+            self.head = idx + 1
+        }
+    }
+
+    pub fn pop_mut(&mut self) -> Option<T> {
+        use core::mem;
+
+        if self.empty() {
+            None
+        } else {
+            self.head -= 1;
+            let last = mem::take(&mut self.data[self.head]);
+
+            Some(last)
+        }
+    }
+}
+
+impl<T, const N: usize> AsRef<[T]> for Stack<T, N> {
+    fn as_ref(&self) -> &[T] {
+        &self.data[0..self.head]
+    }
+}
+
+impl<T, const N: usize, const M: usize> PartialEq<[T; M]> for Stack<T, N>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &[T; M]) -> bool {
+        self.data.iter().eq(other.iter())
+    }
+}
+
+impl<T, const N: usize> PartialEq<&[T]> for Stack<T, N>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &&[T]) -> bool {
+        self.data.iter().eq(other.iter())
+    }
+}
+
+impl<T: Copy + Default, const N: usize> Default for Stack<T, N> {
+    fn default() -> Self {
+        Self {
+            head: 0,
+            data: [T::default(); N],
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 pub mod parser;
+pub mod lexer;
 pub mod preprocessor;
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,8 @@ fn write_dest_file<P: AsRef<Path>>(filename: P, data: &[u8]) -> RuntimeResult<()
     }
 }
 
-fn compile(source: &str) -> RuntimeResult<String> {
+fn compile(frontend: &str, source: &str) -> RuntimeResult<String> {
+    use mossy::lexer;
     use mossy::parser;
     use mossy::preprocessor;
     use mossy::stage::codegen::machine::arch::x86_64;
@@ -69,15 +70,36 @@ fn compile(source: &str) -> RuntimeResult<String> {
     let pre_processed_input = preprocessor::pre_process(&input)
         .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))?;
 
-    parser::parse(&pre_processed_input)
-        .map(|program| {
-            type_check::TypeAnalysis::default()
-                .and_then(|| x86_64::X86_64)
-                .apply(program)
-        })
-        .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))?
-        .map(|insts| insts.into_iter().collect::<String>())
-        .map_err(RuntimeError::Undefined)
+    if frontend == "tokenized" {
+        let preprocessed: String = pre_processed_input.into_iter().map(|(_, c)| c).collect();
+        lexer::lex(&preprocessed)
+            .map(|t| {
+                t.into_iter()
+                    .enumerate()
+                    .collect::<Vec<(usize, lexer::Token)>>()
+            })
+            .and_then(|tokens| {
+                parser::token_parser::parse(&tokens)
+                    .map_err(|e| format!("{:?}", e))
+                    .and_then(|program| {
+                        type_check::TypeAnalysis::default()
+                            .and_then(|| x86_64::X86_64)
+                            .apply(program)
+                    })
+            })
+            .map_err(RuntimeError::Undefined)
+            .map(|insts| insts.into_iter().collect::<String>())
+    } else {
+        parser::parse(&pre_processed_input)
+            .map(|program| {
+                type_check::TypeAnalysis::default()
+                    .and_then(|| x86_64::X86_64)
+                    .apply(program)
+            })
+            .map_err(|e| RuntimeError::Undefined(format!("{:?}", e)))?
+            .map(|insts| insts.into_iter().collect::<String>())
+            .map_err(RuntimeError::Undefined)
+    }
 }
 
 fn assemble<P>(filename: P) -> RuntimeResult<PathBuf>
@@ -150,7 +172,7 @@ fn main() -> RuntimeResult<()> {
         .with_flag(backend)
         .with_flag(frontend)
         .with_flag(help)
-        .with_args_handler(|args, (((ouf, _), _), _)| {
+        .with_args_handler(|args, (((ouf, _), frontend), _)| {
             let (src_files, obj_files) = args
                 .into_iter()
                 .map(|val| val.unwrap())
@@ -169,7 +191,7 @@ fn main() -> RuntimeResult<()> {
                 .into_iter()
                 .map(|file| {
                     read_src_file(&file)
-                        .and_then(|input| compile(&input))
+                        .and_then(|input| compile(&frontend, &input))
                         .and_then(|asm| {
                             let asm_out_file = Path::new(&file).with_extension("s");
                             write_dest_file(&asm_out_file, asm.as_bytes()).map(|_| asm_out_file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,16 @@ fn main() -> RuntimeResult<()> {
     // Flag Definitions
     let help = scrap::Flag::store_true("help", "h", "display usage information.").optional();
     let out_file = scrap::Flag::expect_string("out-file", "o", "a binary output path.").optional();
+    let frontend = scrap::Flag::with_choices(
+        "frontend",
+        "f",
+        "a temporary test frontend toggle.",
+        ["combined".to_string(), "tokenized".to_string()],
+        scrap::StringValue,
+    )
+    .optional()
+    .with_default("combined".to_string());
+
     let backend = scrap::Flag::with_choices(
         "backend",
         "b",
@@ -138,8 +148,9 @@ fn main() -> RuntimeResult<()> {
         .version("0.1.0")
         .with_flag(out_file)
         .with_flag(backend)
+        .with_flag(frontend)
         .with_flag(help)
-        .with_args_handler(|args, ((ouf, _), _)| {
+        .with_args_handler(|args, (((ouf, _), _), _)| {
             let (src_files, obj_files) = args
                 .into_iter()
                 .map(|val| val.unwrap())

--- a/src/parser/token_parser.rs
+++ b/src/parser/token_parser.rs
@@ -1,4 +1,3 @@
-use parcel::parsers::character::*;
 use parcel::prelude::v1::*;
 
 use crate::lexer::{Token, TokenType};
@@ -20,14 +19,14 @@ pub enum ParseErr {
 
 /// parse expects a character slice as input and attempts to parse a valid
 /// expression, returning a parse error if it is invalid.
-pub fn parse(input: &[(usize, char)]) -> Result<CompilationUnit, ParseErr> {
+pub fn parse(input: &[(usize, Token)]) -> Result<CompilationUnit, ParseErr> {
     parcel::one_or_more(
         function_definition()
             .map(ast::GlobalDecls::FuncDefinition)
             .or(|| {
                 parcel::left(parcel::join(
                     function_prototype(),
-                    whitespace_wrapped(expect_character(';')),
+                    expect_tokentype(TokenType::SemiColon),
                 ))
                 .map(ast::GlobalDecls::FuncProto)
             })
@@ -55,23 +54,23 @@ pub fn parse(input: &[(usize, char)]) -> Result<CompilationUnit, ParseErr> {
     .map(CompilationUnit::new)
 }
 
-fn function_prototype<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], FunctionProto> {
+fn function_prototype<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], FunctionProto> {
     parcel::join(
-        parcel::join(type_declarator(), whitespace_wrapped(identifier())),
-        expect_character('(').and_then(|_| {
+        parcel::join(type_declarator(), identifier()),
+        expect_tokentype(TokenType::LParen).and_then(|_| {
             parcel::left(parcel::join(
                 parcel::join(
                     parcel::zero_or_more(
                         parcel::join(
-                            whitespace_wrapped(type_declarator()),
+                            type_declarator(),
                             parcel::left(parcel::join(
                                 identifier(),
-                                whitespace_wrapped(expect_character(',')),
+                                expect_tokentype(TokenType::Comma),
                             )),
                         )
                         .map(|(ty, id)| ast::Parameter::new(id, ty)),
                     ),
-                    parcel::join(whitespace_wrapped(type_declarator()), identifier())
+                    parcel::join(type_declarator(), identifier())
                         .map(|(ty, id)| ast::Parameter::new(id, ty)),
                 )
                 .map(|(mut head, tail)| {
@@ -80,27 +79,32 @@ fn function_prototype<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Func
                 })
                 .or(|| {
                     parcel::zero_or_more(
-                        parcel::join(whitespace_wrapped(type_declarator()), identifier())
+                        parcel::join(type_declarator(), identifier())
                             .map(|(ty, id)| ast::Parameter::new(id, ty)),
                     )
                 }),
-                whitespace_wrapped(expect_character(')')),
+                expect_tokentype(TokenType::RParen),
             ))
         }),
     )
     .map(|((ty, id), params)| FunctionProto::new(id, ty, params))
 }
 
-fn function_definition<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], FunctionDefinition> {
+fn function_definition<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], FunctionDefinition> {
     parcel::join(function_prototype(), compound_statements())
         .map(|(proto, block)| FunctionDefinition::new(proto, block))
 }
 
-fn compound_statements<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], CompoundStmts> {
-    character_wrapped('{', '}', parcel::zero_or_more(statement())).map(CompoundStmts::new)
+fn compound_statements<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], CompoundStmts> {
+    tokentype_wrapped(
+        TokenType::LBrace,
+        TokenType::RBrace,
+        parcel::zero_or_more(statement()),
+    )
+    .map(CompoundStmts::new)
 }
 
-fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
+fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
     semicolon_terminated_statement(declaration())
         .or(if_statement)
         .or(while_statement)
@@ -111,23 +115,20 @@ fn statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
 
 fn semicolon_terminated_statement<'a, P>(
     term: P,
-) -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode>
+) -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode>
 where
-    P: parcel::Parser<'a, &'a [(usize, char)], StmtNode> + 'a,
+    P: parcel::Parser<'a, &'a [(usize, Token)], StmtNode> + 'a,
 {
-    parcel::left(parcel::join(
-        term,
-        whitespace_wrapped(expect_character(';')),
-    ))
+    parcel::left(parcel::join(term, expect_tokentype(TokenType::SemiColon)))
 }
 
-fn declaration<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
+fn declaration<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
     parcel::join(
         type_declarator(),
-        whitespace_wrapped(parcel::join(
+        parcel::join(
             identifier(),
-            character_wrapped('[', ']', unsigned_number()),
-        )),
+            tokentype_wrapped(TokenType::LBracket, TokenType::RBracket, unsigned_number()),
+        ),
     )
     .map(|(ty, (id, size))| {
         let size = match size {
@@ -147,62 +148,60 @@ fn declaration<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
     .or(|| {
         parcel::join(
             type_declarator(),
-            whitespace_wrapped(parcel::one_or_more(parcel::left(parcel::join(
+            parcel::one_or_more(parcel::left(parcel::join(
                 identifier(),
-                whitespace_wrapped(expect_character(',').optional()),
-            )))),
+                expect_tokentype(TokenType::Comma).optional(),
+            ))),
         )
         .map(|(ty, ids)| type_check::ast::Declaration::Scalar(ty, ids))
         .map(StmtNode::Declaration)
     })
 }
 
-fn if_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
+fn if_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
     parcel::join(
         if_head(),
-        parcel::optional(
-            whitespace_wrapped(expect_str("else")).and_then(|_| compound_statements()),
-        ),
+        parcel::optional(expect_tokentype(TokenType::Else).and_then(|_| compound_statements())),
     )
     .map(|((cond, cond_true), cond_false)| StmtNode::If(cond, cond_true, cond_false))
 }
 
-fn if_head<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], (ExprNode, CompoundStmts)> {
-    whitespace_wrapped(expect_str("if")).and_then(|_| {
+fn if_head<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], (ExprNode, CompoundStmts)> {
+    expect_tokentype(TokenType::If).and_then(|_| {
         parcel::join(
-            character_wrapped('(', ')', expression()),
+            tokentype_wrapped(TokenType::LParen, TokenType::RParen, expression()),
             compound_statements(),
         )
     })
 }
 
-fn while_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
-    whitespace_wrapped(expect_str("while"))
+fn while_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
+    expect_tokentype(TokenType::While)
         .and_then(|_| {
             parcel::join(
-                character_wrapped('(', ')', expression()),
+                tokentype_wrapped(TokenType::LParen, TokenType::RParen, expression()),
                 compound_statements(),
             )
         })
         .map(|(cond, block)| StmtNode::While(cond, block))
 }
 
-fn for_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
-    whitespace_wrapped(expect_str("for"))
+fn for_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
+    expect_tokentype(TokenType::For)
         .and_then(|_| {
             parcel::join(
-                character_wrapped(
-                    '(',
-                    ')',
+                tokentype_wrapped(
+                    TokenType::LParen,
+                    TokenType::RParen,
                     parcel::join(
                         parcel::left(parcel::join(
                             preop_statement(),
-                            whitespace_wrapped(expect_character(';')),
+                            expect_tokentype(TokenType::SemiColon),
                         )),
                         parcel::join(
                             parcel::left(parcel::join(
                                 expression(),
-                                whitespace_wrapped(expect_character(';')),
+                                expect_tokentype(TokenType::SemiColon),
                             )),
                             postop_statement(),
                         ),
@@ -216,46 +215,33 @@ fn for_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode>
         })
 }
 
-fn preop_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
+fn preop_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
     assignment().map(StmtNode::Expression)
 }
 
-fn postop_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
+fn postop_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
     expression().map(StmtNode::Expression)
 }
 
-fn return_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], StmtNode> {
+fn return_statement<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], StmtNode> {
     parcel::right(parcel::join(
-        whitespace_wrapped(expect_str("return")),
+        expect_tokentype(TokenType::Return),
         expression().optional(),
     ))
     .map(StmtNode::Return)
 }
 
-fn expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     assignment()
 }
 
-fn new_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    new_assignment()
-}
-
-fn assignment<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn assignment<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
-        whitespace_wrapped(logical()),
-        whitespace_wrapped(expect_character('=')).and_then(|_| whitespace_wrapped(assignment())),
+        logical(),
+        expect_tokentype(TokenType::Equal).and_then(|_| assignment()),
     )
     .map(|(lhs, rhs)| assignment_expr!(lhs, '=', rhs))
     .or(logical)
-}
-
-fn new_assignment<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_logical(),
-        expect_tokentype(TokenType::Equal).and_then(|_| new_assignment()),
-    )
-    .map(|(lhs, rhs)| assignment_expr!(lhs, '=', rhs))
-    .or(new_logical)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -264,36 +250,14 @@ enum LogicalExprOp {
     And,
 }
 
-fn logical<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn logical<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         bitwise(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(expect_str("||"))
-                .map(|_| LogicalExprOp::Or)
-                .or(|| whitespace_wrapped(expect_str("&&")).map(|_| LogicalExprOp::And)),
-            whitespace_wrapped(bitwise()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                LogicalExprOp::Or => binary_logical_expr!(lhs, "||", rhs),
-                LogicalExprOp::And => binary_logical_expr!(lhs, "&&", rhs),
-            })
-    })
-}
-
-fn new_logical<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_bitwise(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::PipePipe)
                 .map(|_| LogicalExprOp::Or)
                 .or(|| expect_tokentype(TokenType::AmpersandAmpersand).map(|_| LogicalExprOp::And)),
-            new_bitwise(),
+            bitwise(),
         ))
         .map(unzip),
     )
@@ -315,46 +279,15 @@ enum BitwiseExprOp {
     And,
 }
 
-fn bitwise<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn bitwise<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         equality(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(
-                expect_str("|")
-                    .peek_next(any_character().predicate(|&c| c != '|'))
-                    .map(|_| BitwiseExprOp::Or)
-                    .or(|| expect_str("^").map(|_| BitwiseExprOp::Xor))
-                    .or(|| {
-                        expect_str("&")
-                            .peek_next(any_character().predicate(|&c| c != '&'))
-                            .map(|_| BitwiseExprOp::And)
-                    }),
-            ),
-            whitespace_wrapped(equality()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                BitwiseExprOp::Or => bitwise_expr!(lhs, "|", rhs),
-                BitwiseExprOp::Xor => bitwise_expr!(lhs, "^", rhs),
-                BitwiseExprOp::And => bitwise_expr!(lhs, "&", rhs),
-            })
-    })
-}
-
-fn new_bitwise<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_equality(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::Pipe)
                 .map(|_| BitwiseExprOp::Or)
                 .or(|| expect_tokentype(TokenType::Carat).map(|_| BitwiseExprOp::Xor))
                 .or(|| expect_tokentype(TokenType::Ampersand).map(|_| BitwiseExprOp::And)),
-            new_equality(),
+            equality(),
         ))
         .map(unzip),
     )
@@ -376,38 +309,14 @@ enum EqualityExprOp {
     NotEqual,
 }
 
-fn equality<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn equality<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         relational(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(
-                expect_str("==")
-                    .map(|_| EqualityExprOp::Equal)
-                    .or(|| expect_str("!=").map(|_| EqualityExprOp::NotEqual)),
-            ),
-            whitespace_wrapped(relational()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                EqualityExprOp::Equal => equality_expr!(lhs, "==", rhs),
-                EqualityExprOp::NotEqual => equality_expr!(lhs, "!=", rhs),
-            })
-    })
-}
-
-fn new_equality<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_relational(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::EqualEqual)
                 .map(|_| EqualityExprOp::Equal)
                 .or(|| expect_tokentype(TokenType::BangEqual).map(|_| EqualityExprOp::NotEqual)),
-            new_relational(),
+            relational(),
         ))
         .map(unzip),
     )
@@ -430,41 +339,9 @@ enum RelationalExprOp {
     GreaterEqual,
 }
 
-fn relational<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn relational<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         bitwise_shift(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(
-                expect_str("<=")
-                    .map(|_| RelationalExprOp::LessEqual)
-                    .or(|| expect_str(">=").map(|_| RelationalExprOp::GreaterEqual))
-                    .or(|| expect_str("<").map(|_| RelationalExprOp::LessThan))
-                    .or(|| expect_str(">").map(|_| RelationalExprOp::GreaterThan)),
-            ),
-            whitespace_wrapped(bitwise_shift()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                RelationalExprOp::LessThan => ExprNode::LessThan(Box::new(lhs), Box::new(rhs)),
-                RelationalExprOp::LessEqual => ExprNode::LessEqual(Box::new(lhs), Box::new(rhs)),
-                RelationalExprOp::GreaterThan => {
-                    ExprNode::GreaterThan(Box::new(lhs), Box::new(rhs))
-                }
-                RelationalExprOp::GreaterEqual => {
-                    ExprNode::GreaterEqual(Box::new(lhs), Box::new(rhs))
-                }
-            })
-    })
-}
-
-fn new_relational<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_bitwise_shift(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::LessEqual)
                 .map(|_| RelationalExprOp::LessEqual)
@@ -476,7 +353,7 @@ fn new_relational<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNod
                 .or(|| {
                     expect_tokentype(TokenType::GreaterThan).map(|_| RelationalExprOp::GreaterThan)
                 }),
-            new_bitwise_shift(),
+            bitwise_shift(),
         ))
         .map(unzip),
     )
@@ -502,38 +379,14 @@ enum BitwiseShiftExprOp {
     ShiftRight,
 }
 
-fn bitwise_shift<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn bitwise_shift<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         addition(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(
-                expect_str("<<")
-                    .map(|_| BitwiseShiftExprOp::ShiftLeft)
-                    .or(|| expect_str(">>").map(|_| BitwiseShiftExprOp::ShiftRight)),
-            ),
-            whitespace_wrapped(addition()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                BitwiseShiftExprOp::ShiftLeft => bitwise_shift_expr!(lhs, "<<", rhs),
-                BitwiseShiftExprOp::ShiftRight => bitwise_shift_expr!(lhs, ">>", rhs),
-            })
-    })
-}
-
-fn new_bitwise_shift<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_addition(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::LShift)
                 .map(|_| BitwiseShiftExprOp::ShiftLeft)
                 .or(|| expect_tokentype(TokenType::RShift).map(|_| BitwiseShiftExprOp::ShiftRight)),
-            new_addition(),
+            addition(),
         ))
         .map(unzip),
     )
@@ -554,38 +407,14 @@ enum AdditionExprOp {
     Minus,
 }
 
-fn addition<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn addition<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         multiplication(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(
-                expect_character('+')
-                    .map(|_| AdditionExprOp::Plus)
-                    .or(|| expect_character('-').map(|_| AdditionExprOp::Minus)),
-            ),
-            whitespace_wrapped(multiplication()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                AdditionExprOp::Plus => term_expr!(lhs, '+', rhs),
-                AdditionExprOp::Minus => term_expr!(lhs, '-', rhs),
-            })
-    })
-}
-
-fn new_addition<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_multiplication(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::Plus)
                 .map(|_| AdditionExprOp::Plus)
                 .or(|| expect_tokentype(TokenType::Minus).map(|_| AdditionExprOp::Minus)),
-            new_multiplication(),
+            multiplication(),
         ))
         .map(unzip),
     )
@@ -607,43 +436,15 @@ enum MultiplicationExprOp {
     Mod,
 }
 
-fn multiplication<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn multiplication<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         call(),
-        parcel::zero_or_more(parcel::join(
-            whitespace_wrapped(
-                expect_character('*')
-                    .map(|_| MultiplicationExprOp::Star)
-                    .or(|| expect_character('/').map(|_| MultiplicationExprOp::Slash))
-                    .or(|| expect_character('%').map(|_| MultiplicationExprOp::Mod)),
-            ),
-            whitespace_wrapped(call()),
-        ))
-        .map(unzip),
-    )
-    .map(|(first_expr, (operators, operands))| {
-        operators
-            .into_iter()
-            .zip(operands.into_iter())
-            .fold(first_expr, |lhs, (operator, rhs)| match operator {
-                MultiplicationExprOp::Star => {
-                    factor_expr!(lhs, '*', rhs)
-                }
-                MultiplicationExprOp::Slash => factor_expr!(lhs, '/', rhs),
-                MultiplicationExprOp::Mod => factor_expr!(lhs, '%', rhs),
-            })
-    })
-}
-
-fn new_multiplication<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_call(),
         parcel::zero_or_more(parcel::join(
             expect_tokentype(TokenType::Star)
                 .map(|_| MultiplicationExprOp::Star)
                 .or(|| expect_tokentype(TokenType::Slash).map(|_| MultiplicationExprOp::Slash))
                 .or(|| expect_tokentype(TokenType::PercentSign).map(|_| MultiplicationExprOp::Mod)),
-            new_call(),
+            call(),
         ))
         .map(unzip),
     )
@@ -661,15 +462,15 @@ fn new_multiplication<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Exp
     })
 }
 
-fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         identifier(),
-        whitespace_wrapped(expect_character('(')).and_then(|_| {
+        expect_tokentype(TokenType::LParen).and_then(|_| {
             parcel::left(parcel::join(
                 parcel::join(
                     parcel::zero_or_more(parcel::left(parcel::join(
                         expression(),
-                        whitespace_wrapped(expect_character(',')),
+                        expect_tokentype(TokenType::Comma),
                     ))),
                     expression(),
                 )
@@ -685,7 +486,7 @@ fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
                             None => vec![],
                         })
                 }),
-                whitespace_wrapped(expect_character(')')),
+                expect_tokentype(TokenType::RParen),
             ))
         }),
     )
@@ -693,119 +494,39 @@ fn call<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
     .or(prefix_expression)
 }
 
-fn new_call<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_identifier(),
-        expect_tokentype(TokenType::LParen).and_then(|_| {
-            parcel::left(parcel::join(
-                parcel::join(
-                    parcel::zero_or_more(parcel::left(parcel::join(
-                        new_expression(),
-                        expect_tokentype(TokenType::Comma),
-                    ))),
-                    new_expression(),
-                )
-                .map(|(mut head, tail)| {
-                    head.push(tail);
-                    head
-                })
-                .or(|| {
-                    new_expression()
-                        .optional()
-                        .map(|optional_expr| match optional_expr {
-                            Some(expr) => vec![expr],
-                            None => vec![],
-                        })
-                }),
-                expect_tokentype(TokenType::RParen),
-            ))
-        }),
-    )
-    .map(|(id, exprs)| ExprNode::FunctionCall(id, exprs))
-    .or(new_prefix_expression)
-}
-
-fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
-    whitespace_wrapped(expect_character('*'))
+fn prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
+    expect_tokentype(TokenType::Star)
         .and_then(|_| prefix_expression())
         .map(Box::new)
         .map(ExprNode::Deref)
         .or(|| {
-            whitespace_wrapped(expect_character('&'))
+            expect_tokentype(TokenType::Ampersand)
                 .and_then(|_| identifier())
                 .map(ExprNode::Ref)
         })
         .or(|| {
-            whitespace_wrapped(expect_str("++"))
-                .and_then(|_| prefix_expression())
-                .map(Box::new)
-                .map(ExprNode::PreIncrement)
-        })
-        .or(|| {
-            whitespace_wrapped(expect_str("--"))
-                .and_then(|_| prefix_expression())
-                .map(Box::new)
-                .map(ExprNode::PreDecrement)
-        })
-        // unary logical not
-        .or(|| {
-            whitespace_wrapped(expect_character('!'))
-                .and_then(|_| prefix_expression())
-                .map(Box::new)
-                .map(ExprNode::LogicalNot)
-        })
-        // unary negate
-        .or(|| {
-            whitespace_wrapped(expect_character('-'))
-                .and_then(|_| prefix_expression())
-                // prevent negate from eating `-` on integer literals.
-                .predicate(|e| !matches!(e, ExprNode::Primary(Primary::Integer { .. })))
-                .map(Box::new)
-                .map(ExprNode::Negate)
-        })
-        // unary inverse
-        .or(|| {
-            whitespace_wrapped(expect_character('~'))
-                .and_then(|_| prefix_expression())
-                .map(Box::new)
-                .map(ExprNode::Invert)
-        })
-        .or(post_increment_decrement_expression)
-}
-
-fn new_prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    expect_tokentype(TokenType::Star)
-        .and_then(|_| new_prefix_expression())
-        .map(Box::new)
-        .map(ExprNode::Deref)
-        .or(|| {
-            expect_tokentype(TokenType::Ampersand)
-                .and_then(|_| new_identifier())
-                .map(ExprNode::Ref)
-        })
-        .or(|| {
             expect_tokentype(TokenType::PlusPlus)
-                .and_then(|_| new_prefix_expression())
+                .and_then(|_| prefix_expression())
                 .map(Box::new)
                 .map(ExprNode::PreIncrement)
         })
         .or(|| {
             expect_tokentype(TokenType::MinusMinus)
-                .and_then(|_| new_prefix_expression())
+                .and_then(|_| prefix_expression())
                 .map(Box::new)
                 .map(ExprNode::PreDecrement)
         })
         // unary logical not
         .or(|| {
             expect_tokentype(TokenType::Bang)
-                .and_then(|_| new_prefix_expression())
+                .and_then(|_| prefix_expression())
                 .map(Box::new)
                 .map(ExprNode::LogicalNot)
         })
         // unary negate
         .or(|| {
             expect_tokentype(TokenType::Minus)
-                .and_then(|_| new_prefix_expression())
+                .and_then(|_| prefix_expression())
                 // prevent negate from eating `-` on integer literals.
                 .predicate(|e| !matches!(e, ExprNode::Primary(Primary::Integer { .. })))
                 .map(Box::new)
@@ -814,25 +535,25 @@ fn new_prefix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], 
         // unary inverse
         .or(|| {
             expect_tokentype(TokenType::Tilde)
-                .and_then(|_| new_prefix_expression())
+                .and_then(|_| prefix_expression())
                 .map(Box::new)
                 .map(ExprNode::Invert)
         })
-        .or(new_post_increment_decrement_expression)
+        .or(post_increment_decrement_expression)
 }
 
 fn post_increment_decrement_expression<'a>(
-) -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+) -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::left(parcel::join(
-        whitespace_wrapped(postfix_expression()),
-        expect_str("++"),
+        postfix_expression(),
+        expect_tokentype(TokenType::PlusPlus),
     ))
     .map(Box::new)
     .map(ExprNode::PostIncrement)
     .or(|| {
         parcel::left(parcel::join(
-            whitespace_wrapped(postfix_expression()),
-            whitespace_wrapped(expect_str("--")),
+            postfix_expression(),
+            expect_tokentype(TokenType::MinusMinus),
         ))
         .map(Box::new)
         .map(ExprNode::PostDecrement)
@@ -840,50 +561,19 @@ fn post_increment_decrement_expression<'a>(
     .or(postfix_expression)
 }
 
-fn new_post_increment_decrement_expression<'a>(
-) -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::left(parcel::join(
-        new_postfix_expression(),
-        expect_tokentype(TokenType::PlusPlus),
-    ))
-    .map(Box::new)
-    .map(ExprNode::PostIncrement)
-    .or(|| {
-        parcel::left(parcel::join(
-            new_postfix_expression(),
-            expect_tokentype(TokenType::MinusMinus),
-        ))
-        .map(Box::new)
-        .map(ExprNode::PostDecrement)
-    })
-    .or(new_postfix_expression)
-}
-
-fn postfix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn postfix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     parcel::join(
         identifier(),
         parcel::left(parcel::join(
-            whitespace_wrapped(expect_character('[')).and_then(|_| expression()),
-            whitespace_wrapped(expect_character(']')),
+            expect_tokentype(TokenType::LBracket).and_then(|_| expression()),
+            expect_tokentype(TokenType::RBracket),
         )),
     )
     .map(|(id, expr)| ExprNode::Index(id, Box::new(expr)))
     .or(primary)
 }
 
-fn new_postfix_expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    parcel::join(
-        new_identifier(),
-        parcel::left(parcel::join(
-            expect_tokentype(TokenType::LBracket).and_then(|_| new_expression()),
-            expect_tokentype(TokenType::RBracket),
-        )),
-    )
-    .map(|(id, expr)| ExprNode::Index(id, Box::new(expr)))
-    .or(new_primary)
-}
-
-fn primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
+fn primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     number()
         .map(ExprNode::Primary)
         .or(|| character_literal().map(ExprNode::Primary))
@@ -892,54 +582,18 @@ fn primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
         .or(grouping)
 }
 
-fn new_primary<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
-    new_number()
-        .map(ExprNode::Primary)
-        .or(|| new_character_literal().map(ExprNode::Primary))
-        .or(|| new_string_literal().map(ExprNode::Primary))
-        .or(|| new_identifier().map(|id| ExprNode::Primary(Primary::Identifier(id))))
-        .or(new_grouping)
-}
-
-fn grouping<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ExprNode> {
-    whitespace_wrapped(expect_character('('))
-        .and_then(|_| {
-            parcel::left(parcel::join(
-                expression(),
-                whitespace_wrapped(expect_character(')')),
-            ))
-        })
-        .map(|expr| grouping_expr!(expr))
-}
-
-fn new_grouping<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
+fn grouping<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], ExprNode> {
     expect_tokentype(TokenType::LParen)
         .and_then(|_| {
             parcel::left(parcel::join(
-                new_expression(),
+                expression(),
                 expect_tokentype(TokenType::RParen),
             ))
         })
         .map(|expr| grouping_expr!(expr))
 }
 
-fn string_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
-    character_wrapped(
-        '"',
-        '"',
-        parcel::zero_or_more(
-            ascii_alphanumeric()
-                .or(ascii_whitespace)
-                .or(ascii_control)
-                // escaped quote
-                .or(|| expect_character('\\').and_then(|_| expect_character('\"')))
-                .map(|c| c as u8),
-        ),
-    )
-    .map(ast::Primary::Str)
-}
-
-fn new_string_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
+fn string_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
     expect_tokentype(TokenType::StrLiteral)
         .map(|tok| match tok {
             // guaranteed due to above constraint
@@ -950,15 +604,7 @@ fn new_string_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Pri
         .map(ast::Primary::Str)
 }
 
-fn character_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
-    character_wrapped('\'', '\'', ascii().map(|c| c as u8)).map(|num| Primary::Integer {
-        sign: Signed::Signed,
-        width: IntegerWidth::Eight,
-        value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-    })
-}
-
-fn new_character_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
+fn character_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
     expect_tokentype(TokenType::CharLiteral)
         .map(|tok| match tok {
             // guaranteed due to above constraint
@@ -972,7 +618,7 @@ fn new_character_literal<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], 
         })
 }
 
-fn number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
+fn number<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
     parcel::one_of(vec![
         dec_i8().map(|num| Primary::Integer {
             sign: Signed::Signed,
@@ -1017,52 +663,7 @@ fn number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
     ])
 }
 
-fn new_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
-    parcel::one_of(vec![
-        new_dec_i8().map(|num| Primary::Integer {
-            sign: Signed::Signed,
-            width: IntegerWidth::Eight,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u8().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::Eight,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_i16().map(|num| Primary::Integer {
-            sign: Signed::Signed,
-            width: IntegerWidth::Sixteen,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u16().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::Sixteen,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_i32().map(|num| Primary::Integer {
-            sign: Signed::Signed,
-            width: IntegerWidth::ThirtyTwo,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u32().map(|num| Primary::Integer {
-            sign: Signed::Signed,
-            width: IntegerWidth::ThirtyTwo,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_i64().map(|num| Primary::Integer {
-            sign: Signed::Signed,
-            width: IntegerWidth::SixtyFour,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u64().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::SixtyFour,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-    ])
-}
-
-fn unsigned_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary> {
+fn unsigned_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
     parcel::one_of(vec![
         dec_u8().map(|num| Primary::Integer {
             sign: Signed::Unsigned,
@@ -1087,39 +688,7 @@ fn unsigned_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Primary
     ])
 }
 
-fn new_unsigned_number<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Primary> {
-    parcel::one_of(vec![
-        new_dec_u8().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::Eight,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u16().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::Sixteen,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u32().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::ThirtyTwo,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-        new_dec_u64().map(|num| Primary::Integer {
-            sign: Signed::Unsigned,
-            width: IntegerWidth::SixtyFour,
-            value: crate::util::pad_to_64bit_array(num.to_le_bytes()),
-        }),
-    ])
-}
-
-fn identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], String> {
-    parcel::one_or_more(ascii_alphanumeric().or(|| expect_character('_')))
-        .map(|chars| chars.into_iter().collect::<String>())
-        // guarantee the identifier is not a keyword.
-        .predicate(|str| !RESERVED_KEYWORDS.contains(&str.as_str()))
-}
-
-fn new_identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], String> {
+fn identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], String> {
     expect_tokentype(TokenType::Identifier).map(|t| {
         match t {
             Token::Identifier(id) => id,
@@ -1129,27 +698,9 @@ fn new_identifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], String>
     })
 }
 
-fn type_declarator<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Type> {
-    whitespace_wrapped(
-        parcel::join(
-            type_specifier(),
-            whitespace_wrapped(expect_character('*').one_or_more()),
-        )
-        .map(|(ty, pointer_depth)| {
-            let nested_pointers = pointer_depth.len() - 1;
-            (0..nested_pointers)
-                .into_iter()
-                .fold(Type::Pointer(Box::new(ty)), |acc, _| {
-                    Type::Pointer(Box::new(acc))
-                })
-        }),
-    )
-    .or(type_specifier)
-}
-
-fn new_type_declarator<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Type> {
+fn type_declarator<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Type> {
     parcel::join(
-        new_type_specifier(),
+        type_specifier(),
         expect_tokentype(TokenType::Star).one_or_more(),
     )
     .map(|(ty, pointer_depth)| {
@@ -1160,67 +711,10 @@ fn new_type_declarator<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Ty
                 Type::Pointer(Box::new(acc))
             })
     })
-    .or(new_type_specifier)
+    .or(type_specifier)
 }
 
-fn type_specifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], Type> {
-    parcel::join(
-        whitespace_wrapped(parcel::one_of(vec![
-            expect_str("signed").map(|_| Signed::Signed),
-            expect_str("unsigned").map(|_| Signed::Unsigned),
-        ]))
-        .optional(),
-        whitespace_wrapped(parcel::one_of(vec![
-            //
-            // long parser
-            //
-            parcel::one_of(vec![
-                // long long int
-                whitespace_wrapped(expect_str("long"))
-                    .and_then(|_| whitespace_wrapped(expect_str("long")))
-                    .and_then(|_| whitespace_wrapped(expect_str("int"))),
-                // long long
-                whitespace_wrapped(expect_str("long"))
-                    .and_then(|_| whitespace_wrapped(expect_str("long"))),
-                // long int
-                whitespace_wrapped(expect_str("long"))
-                    .and_then(|_| whitespace_wrapped(expect_str("int"))),
-                // long
-                parcel::BoxedParser::new(expect_str("long")),
-            ])
-            .map(|_| Type::Integer(Signed::Signed, IntegerWidth::SixtyFour)),
-            //
-            // int parser
-            //
-            expect_str("int").map(|_| Type::Integer(Signed::Signed, IntegerWidth::ThirtyTwo)),
-            //
-            // short parser
-            //
-            parcel::one_of(vec![
-                // short int
-                whitespace_wrapped(expect_str("short"))
-                    .and_then(|_| whitespace_wrapped(expect_str("int"))),
-                // short
-                parcel::BoxedParser::new(expect_str("short")),
-            ])
-            .map(|_| Type::Integer(Signed::Signed, IntegerWidth::Sixteen)),
-            //
-            // char parser
-            //
-            expect_str("char").map(|_| Type::Integer(Signed::Signed, IntegerWidth::Eight)),
-            //
-            // void parser
-            //
-            expect_str("void").map(|_| Type::Void),
-        ])),
-    )
-    .map(|(sign, ty)| match (sign, ty) {
-        (Some(sign), Type::Integer(_, width)) => Type::Integer(sign, width),
-        (_, ty) => ty,
-    })
-}
-
-fn new_type_specifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Type> {
+fn type_specifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Type> {
     parcel::join(
         parcel::one_of(vec![
             expect_tokentype(TokenType::Signed).map(|_| Signed::Signed),
@@ -1276,7 +770,7 @@ fn new_type_specifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, Token)], Typ
     })
 }
 
-macro_rules! new_numeric_type_parser {
+macro_rules! numeric_type_parser {
     ($(unsigned, $parser_name:ident, $ret_type:ty,)*) => {
         $(
         #[allow(unused)]
@@ -1360,103 +854,6 @@ macro_rules! new_numeric_type_parser {
     };
 }
 
-macro_rules! numeric_type_parser {
-    ($(unsigned, $parser_name:ident, $ret_type:ty,)*) => {
-        $(
-        #[allow(unused)]
-        fn $parser_name<'a>() -> impl Parser<'a, &'a [(usize, char)], $ret_type> {
-            move |input: &'a [(usize, char)]| {
-                let preparsed_input = input;
-                let res = parcel::one_or_more(digit(10))
-                    .map(|digits| {
-                        let vd: String = digits.into_iter().collect();
-                        vd.parse::<$ret_type>()
-                    })
-                    .parse(input);
-
-                match res {
-                    Ok(MatchStatus::Match {
-                        span,
-                        remainder,
-                        inner: Ok(u),
-                    }) => Ok(MatchStatus::Match {
-                        span,
-                        remainder,
-                        inner: u,
-                    }),
-
-                    Ok(MatchStatus::Match {
-                        span: _,
-                        remainder: _,
-                        inner: Err(_),
-                    }) => Ok(MatchStatus::NoMatch(preparsed_input)),
-
-                    Ok(MatchStatus::NoMatch(remainder)) => Ok(MatchStatus::NoMatch(remainder)),
-                    Err(e) => Err(e),
-                }
-            }
-        }
-    )*
-    };
-    ($(signed, $parser_name:ident, $ret_type:ty,)*) => {
-        $(
-        #[allow(unused)]
-        fn $parser_name<'a>() -> impl Parser<'a, &'a [(usize, char)], $ret_type> {
-            move |input: &'a [(usize, char)]| {
-                let preparsed_input = input;
-                let res = parcel::join(whitespace_wrapped(expect_character('-')).optional(), parcel::one_or_more(digit(10)))
-                    .map(|(negative, digits)| {
-                        let vd: String = if negative.is_some() {
-                            format!("-{}", digits.into_iter().collect::<String>())
-                        } else {
-                            digits.into_iter().collect()
-                        };
-                        vd.parse::<$ret_type>()
-                    })
-                    .parse(input);
-
-                match res {
-                    Ok(MatchStatus::Match {
-                        span,
-                        remainder,
-                        inner: Ok(u),
-                    }) => Ok(MatchStatus::Match {
-                        span,
-                        remainder,
-                        inner: u,
-                    }),
-
-                    Ok(MatchStatus::Match {
-                        span: _,
-                        remainder: _,
-                        inner: Err(_),
-                    }) => Ok(MatchStatus::NoMatch(preparsed_input)),
-
-                    Ok(MatchStatus::NoMatch(remainder)) => Ok(MatchStatus::NoMatch(remainder)),
-                    Err(e) => Err(e),
-                }
-            }
-        }
-    )*
-    };
-}
-
-#[rustfmt::skip]
-new_numeric_type_parser!(
-    signed, new_dec_i8, i8,
-    signed, new_dec_i16, i16,
-    signed, new_dec_i32, i32,
-    signed, new_dec_i64, i64,
-);
-
-#[rustfmt::skip]
-new_numeric_type_parser!(
-    unsigned, new_dec_u8, u8,
-    unsigned, new_dec_u16, u16,
-    unsigned, new_dec_u32, u32,
-    unsigned, new_dec_u64, u64,
-);
-
 #[rustfmt::skip]
 numeric_type_parser!(
     signed, dec_i8, i8,
@@ -1472,74 +869,6 @@ numeric_type_parser!(
     unsigned, dec_u32, u32,
     unsigned, dec_u64, u64,
 );
-
-fn ascii<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
-    parcel::right(parcel::join(
-        expect_character('\\'),
-        expect_character('\\')
-            .map(|_| '\\')
-            .or(|| expect_character('\'').map(|_| '\''))
-            .or(|| expect_character('"').map(|_| '"')),
-    ))
-    .or(ascii_alphanumeric)
-    .or(ascii_whitespace)
-    .or(ascii_control)
-    .or(|| any_character().predicate(|c| c.is_ascii()))
-}
-
-fn ascii_whitespace<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
-    parcel::right(parcel::join(
-        expect_character('\\'),
-        expect_character('n')
-            .map(|_| '\n')
-            .or(|| expect_character('t').map(|_| '\t')),
-    ))
-    .or(any_character)
-    .predicate(|c| c.is_ascii_whitespace())
-}
-
-fn ascii_alphanumeric<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
-    any_character().predicate(|c| c.is_ascii_alphanumeric())
-}
-
-fn ascii_control<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
-    parcel::right(parcel::join(
-        expect_character('\\'),
-        expect_character('r')
-            .map(|_| '\r')
-            .or(|| expect_character('0').map(|_| '\0')),
-    ))
-    .or(|| any_character().predicate(|c| c.is_ascii_control()))
-}
-
-fn whitespace_wrapped<'a, P, B>(parser: P) -> impl Parser<'a, &'a [(usize, char)], B>
-where
-    B: 'a,
-    P: Parser<'a, &'a [(usize, char)], B> + 'a,
-{
-    parcel::right(parcel::join(
-        parcel::zero_or_more(whitespace()),
-        parcel::left(parcel::join(parser, parcel::zero_or_more(whitespace()))),
-    ))
-}
-
-fn character_wrapped<'a, P, B>(
-    prefix: char,
-    suffix: char,
-    parser: P,
-) -> impl Parser<'a, &'a [(usize, char)], B>
-where
-    B: 'a,
-    P: Parser<'a, &'a [(usize, char)], B> + 'a,
-{
-    parcel::right(parcel::join(
-        whitespace_wrapped(expect_character(prefix)),
-        parcel::left(parcel::join(
-            parser,
-            whitespace_wrapped(expect_character(suffix)),
-        )),
-    ))
-}
 
 fn tokentype_wrapped<'a, P, B>(
     prefix: TokenType,

--- a/src/stage/codegen/machine/arch/x86_64/mod.rs
+++ b/src/stage/codegen/machine/arch/x86_64/mod.rs
@@ -60,8 +60,7 @@ impl CompilationStage<ast::TypedProgram, Vec<String>, String> for X86_64 {
                     ast::TypedGlobalDecls::Var(ast::Declaration::Scalar(ty, identifiers)) => {
                         let globals = identifiers
                             .iter()
-                            .map(|id| codegen_global_symbol(&ty, id, 1))
-                            .flatten()
+                            .flat_map(|id| codegen_global_symbol(&ty, id, 1))
                             .collect();
                         Ok(globals)
                     }

--- a/src/stage/type_check/scopes.rs
+++ b/src/stage/type_check/scopes.rs
@@ -75,20 +75,18 @@ impl Scope {
     pub fn ordered_local_declarations(&self) -> Vec<(Type, usize)> {
         self.local_slots
             .iter()
-            .map(|id| {
+            .flat_map(|id| {
                 self.symbols
                     .get(id.as_str())
                     .map(|dm| (dm.r#type.clone(), dm.elems.unwrap_or(1)))
             })
-            .flatten()
             .collect()
     }
 
     pub fn ordered_parameter_declarations(&self) -> Vec<Type> {
         self.parameter_slots
             .iter()
-            .map(|id| self.symbols.get(id.as_str()).map(|dm| (dm.r#type.clone())))
-            .flatten()
+            .flat_map(|id| self.symbols.get(id.as_str()).map(|dm| (dm.r#type.clone())))
             .collect()
     }
 }


### PR DESCRIPTION
# Introduction
This PR begins the process of breaking out the Lexer from the Parser and updating the parser to operate off of a stream of tokens. Initial implementations stands up an entirely new parser alongside the old combined lexer/parser.
# Linked Issues
resolves #152 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
